### PR TITLE
release

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -39,7 +39,7 @@
 &kp TAB    &kp Q  &kp W  &kp E     &kp R                &kp T                   &kp Y      &kp U      &kp I        &kp O    &kp P     &kp BACKSPACE
 &kp LCTRL  &kp A  &kp S  &kp D     &kp F                &kp G                   &kp H      &kp J      &kp K        &kp L    &kp SEMI  &kp SQT
 &kp LSHFT  &kp Z  &kp X  &kp C     &kp V                &kp B                   &kp N      &kp M      &kp COMMA    &kp DOT  &kp FSLH  &kp RIGHT_ALT
-                         &kp LGUI  &lt LOWER LG(SPACE)  &mt LEFT_SHIFT SPACE    &kp ENTER  &mo RAISE  &to ADJUST
+                         &kp LGUI  &lt LOWER LG(SPACE)  &mt LEFT_SHIFT SPACE    &kp ENTER  &mo RAISE  &tog ADJUST
             >;
         };
 
@@ -66,7 +66,7 @@
 &kp TAB         &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6     &kp F7          &kp F8          &kp F9           &kp F10  &mt F11 F12
 &kp LCTRL       &bt BT_CLR    &out OUT_TOG  &trans        &trans        &trans                  &trans     &trans          &kp UP_ARROW    &trans           &trans   &trans
 &kt LEFT_SHIFT  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &trans     &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans   &kp RIGHT_ALT
-                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &to BASE
+                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &trans
             >;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -14,18 +14,6 @@
 #define ADJUST 3
 
 / {
-    behaviors {
-        ht: hold_tap {
-            label = "hold_tap";
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <220>;
-            quick-tap-ms = <150>;
-            global-quick-tap;
-            bindings = <&kp>, <&kp>;
-        };
-    };
 
     combos {
         compatible = "zmk,combos";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -14,7 +14,6 @@
 #define ADJUST 3
 
 / {
-
     combos {
         compatible = "zmk,combos";
 
@@ -66,7 +65,7 @@
 &kp TAB         &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6     &kp F7          &kp F8          &kp F9           &kp F10  &mt F11 F12
 &kp LCTRL       &bt BT_CLR    &out OUT_TOG  &trans        &trans        &trans                  &trans     &trans          &kp UP_ARROW    &trans           &trans   &trans
 &kt LEFT_SHIFT  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &trans     &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans   &kp RIGHT_ALT
-                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &trans
+                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &tog BASE
             >;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -39,7 +39,7 @@
 &kp TAB    &kp Q  &kp W  &kp E     &kp R                &kp T                   &kp Y      &kp U      &kp I        &kp O    &kp P     &kp BACKSPACE
 &kp LCTRL  &kp A  &kp S  &kp D     &kp F                &kp G                   &kp H      &kp J      &kp K        &kp L    &kp SEMI  &kp SQT
 &kp LSHFT  &kp Z  &kp X  &kp C     &kp V                &kp B                   &kp N      &kp M      &kp COMMA    &kp DOT  &kp FSLH  &kp RIGHT_ALT
-                         &kp LGUI  &lt LOWER LG(SPACE)  &mt LEFT_SHIFT SPACE    &kp ENTER  &mo RAISE  &tog ADJUST
+                         &kp LGUI  &lt LOWER LG(SPACE)  &mt LEFT_SHIFT SPACE    &kp ENTER  &mo RAISE  &to ADJUST
             >;
         };
 
@@ -66,7 +66,7 @@
 &kp TAB         &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6     &kp F7          &kp F8          &kp F9           &kp F10  &mt F11 F12
 &kp LCTRL       &bt BT_CLR    &out OUT_TOG  &trans        &trans        &trans                  &trans     &trans          &kp UP_ARROW    &trans           &trans   &trans
 &kt LEFT_SHIFT  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &trans     &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans   &kp RIGHT_ALT
-                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &trans
+                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &to BASE
             >;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -7,6 +7,8 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/outputs.h>
 
 #define BASE   0
 #define LOWER  1
@@ -44,10 +46,10 @@
 
         lower_layer {
             bindings = <
-&kp TAB         &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR  &kp PERCENT              &kp CARET       &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&kp LCTRL       &kp N1           &kp N2       &kp N3    &kp N4      &kp N5                   &kp MINUS       &kp EQUAL      &kp GRAVE     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_SHIFT  &kp N6           &kp N7       &kp N8    &kp N9      &kp N0                   &kp UNDERSCORE  &kt PLUS       &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp RIGHT_ALT
-                                              &kp LGUI  &trans      &mt LEFT_SHIFT SPACE     &kp ENTER       &trans         &trans
+&kp TAB         &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&kp LCTRL       &kp N1           &kp N2       &kp N3    &kp N4      &kp N5                  &kp MINUS       &kp EQUAL      &kp GRAVE     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_SHIFT  &kp N6           &kp N7       &kp N8    &kp N9      &kp N0                  &kp UNDERSCORE  &kt PLUS       &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp RIGHT_ALT
+                                              &kp LGUI  &trans      &mt LEFT_SHIFT SPACE    &kp ENTER       &trans         &trans
             >;
         };
 
@@ -65,7 +67,7 @@
 &kp TAB         &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6     &kp F7          &kp F8          &kp F9           &kp F10  &mt F11 F12
 &kp LCTRL       &bt BT_CLR    &out OUT_TOG  &trans        &trans        &trans                  &trans     &trans          &kp UP_ARROW    &trans           &trans   &trans
 &kt LEFT_SHIFT  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &trans     &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans   &kp RIGHT_ALT
-                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &tog BASE
+                                            &kp LEFT_GUI  &trans        &mt LEFT_SHIFT SPACE    &kp ENTER  &trans          &trans
             >;
         };
     };


### PR DESCRIPTION
- 重構：移除`hold_tap`行為和綁定
- 工作: 在`config/corne.keymap`中將`&amp;amp;amp;to ADJUST`的綁定更新為`&amp;amp;amp;to BASE`
- 風格：更新adjust_layer和lower_layer中的按鍵綁定
- 風格：調整`combo_esc`超時值
- adjust層變更layer更換tog BASE為透明trans
