### PR TITLE
工作: 調整 combo_return-base 的 timeout 並新增測試分支來觸發工作流程

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - "release"
+      - "test"
 
 jobs:
   build:

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -32,8 +32,9 @@
         };
 
         combo_return-base {
-            bindings = <&to BASE>;
+            timeout-ms = <50>
             key-positions = <35 24>;
+            bindings = <&to BASE>;
         };
     };
 


### PR DESCRIPTION
- 在 `.github/workflows/build.yml` 中將 `test` 分支新增到觸發工作流程的分支列表中
- 將 `config/corne.keymap` 中的 `combo_return-base` 的 timeout 更改為 `50` 毫秒

Signed-off-by: DAST-HomePC <jackie@dast.tw>
