### PR TITLE
重構：更新各種組合的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -20,19 +20,16 @@
         compatible = "zmk,combos";
 
         combo_esc {
-            timeout-ms = <50>;
             key-positions = <0 1>;
             bindings = <&kp ESC>;
         };
 
         combo_del {
-            timeout-ms = <50>;
             key-positions = <10 11>;
             bindings = <&kp DEL>;
         };
 
         combo_return-base {
-            timeout-ms = <50>;
             key-positions = <34 35>;
             bindings = <&to 0>;
         };
@@ -49,10 +46,10 @@
 
         base_layer {
             bindings = <
-&kp TAB         &kp Q  &kp W  &kp E     &kp R            &kp T                   &kp Y      &kp U  &kp I      &kp O    &kp P     &kp BACKSPACE
-&kp LCTRL       &kp A  &kp S  &kp D     &kp F            &kp G                   &kp H      &kp J  &kp K      &kp L    &kp SEMI  &kp SQT
-&kp LEFT_SHIFT  &kp Z  &kp X  &kp C     &kp V            &kp B                   &kp N      &kp M  &kp COMMA  &kp DOT  &kp FSLH  &kp RIGHT_ALT
-                              &kp LGUI  &lt 1 LG(SPACE)  &mt LEFT_SHIFT SPACE    &kp ENTER  &mo 2  &tog 3
+&kp TAB         &kp Q  &kp W  &kp E     &kp R                &kp T                   &kp Y      &kp U      &kp I      &kp O    &kp P     &kp BACKSPACE
+&kp LCTRL       &kp A  &kp S  &kp D     &kp F                &kp G                   &kp H      &kp J      &kp K      &kp L    &kp SEMI  &kp SQT
+&kp LEFT_SHIFT  &kp Z  &kp X  &kp C     &kp V                &kp B                   &kp N      &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp RIGHT_ALT
+                              &kp LGUI  &lt LOWER LG(SPACE)  &mt LEFT_SHIFT SPACE    &kp ENTER  &mo RAISE  &tog ADJUST
             >;
         };
 


### PR DESCRIPTION
- 移除 combo_esc、combo_del 和 combo_return-base 的 timeout-ms
- 更新 combo_esc、combo_del 和 combo_return-base 的按鍵位置
- 更新 combo_esc、combo_del 和 combo_return-base 的綁定
- 新增 combo_return-base 的新組合
- 更新 combo_tab、combo_q、combo_w、combo_e、combo_r、combo_t、combo_y、combo_u、combo_i、combo_o、combo_p、combo_a、combo_s、combo_d、combo_f、combo_g、combo_h、combo_j、combo_k、combo_l、combo_z、combo_x、combo_c、combo_v、combo_b、combo_n、combo_m、combo_comma、combo_dot、combo_fslash、combo_lgui、combo_lt、combo_left_shift、combo_space、combo_enter、combo_mo、combo_tog 的按鍵位置

請記得翻譯所有給定的 git commit 訊息。

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
