### PR TITLE
事務：更新按鍵綁定和行為配置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -33,12 +33,6 @@
             key-positions = <34 35>;
             bindings = <&to 0>;
         };
-
-        combo_tilde {
-            bindings = <&kp TILDE>;
-            key-positions = <0 36>;
-            layers = <0>;
-        };
     };
 
     behaviors {
@@ -48,7 +42,7 @@
             bindings = <&kp TAB>, <&kp TILDE>;
 
             #binding-cells = <0>;
-            mods = <(MOD_RALT)>;
+            mods = <(MOD_LGUI)>;
         };
     };
 


### PR DESCRIPTION
- 在 `config/corne.keymap` 中刪除 `combo_tilde` 的按鍵綁定
- 將 `behaviors` 部分的 `binding-cells` 的 `mods` 值更改

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
