### PR TITLE
重構：更新 corne.keymap 檔案中的綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -31,7 +31,7 @@
 
         combo_return-base {
             key-positions = <34 35>;
-            bindings = <&to 0>;
+            bindings = <&to BASE>;
         };
     };
 


### PR DESCRIPTION
- 在 `config/corne.keymap` 檔案的 `combo_return-base` 部分將綁定從 `to 0` 更改為 `to BASE`。

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
