### PR TITLE
習慣: 更新 `LCTRL` 和 `KP LSHIFT` 的鍵繫結

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -69,10 +69,10 @@
 
         raise_layer {
             bindings = <
-&gresc      &kp N1      &kp N2      &kp N3             &kp N4           &kp N5              &kp N6         &kp N7    &kp N8    &kp N9     &kp N0  &kp BSPC
-&kp LCTRL   &trans      &kp C_PREV  &kp C_PLAY_PAUSE   &kp C_NEXT       &kp HOME            &kp PAGE_UP    &trans    &kp UP    &trans     &trans  &trans
-&kp LSHIFT  &caps_word  &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp END             &kp PAGE_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &trans  &kp RALT
-                                    &kp LGUI           &trans           &mt LSHIFT SPACE    &kp ENTER      &trans    &trans
+&gresc      &kp N1        &kp N2      &kp N3             &kp N4           &kp N5              &kp N6         &kp N7    &kp N8    &kp N9     &kp N0  &kp BSPC
+&kp LCTRL   &trans        &kp C_PREV  &kp C_PLAY_PAUSE   &kp C_NEXT       &kp HOME            &kp PAGE_UP    &trans    &kp UP    &trans     &trans  &trans
+&kp LSHIFT  &kp CAPSLOCK  &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp END             &kp PAGE_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &trans  &kp RALT
+                                      &kp LGUI           &trans           &mt LSHIFT SPACE    &kp ENTER      &trans    &trans
             >;
         };
 


### PR DESCRIPTION
- 將 `LCTRL` 的繫結由 `trans` 更改為 `&amp;trans`
- 將 `KP LSHIFT` 的繫結由 `caps_word` 更改為 `&amp;kp CAPSLOCK`

Signed-off-by: Macbook <jackie@dast.tw>
