### PR TITLE
功能：在多个层次中添加“&amp;#43;”和“trans”的绑定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -60,7 +60,7 @@
 
         lower_layer {
             bindings = <
-&gresc  &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR  &kp PERCENT    &kp CARET       &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&trans  &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR  &kp PERCENT    &kp CARET       &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &trans  &kp N1           &kp N2       &kp N3    &kp N4      &kp N5         &kp MINUS       &kp EQUAL      &kp GRAVE     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
 &trans  &kp N6           &kp N7       &kp N8    &kp N9      &kp N0         &kp UNDERSCORE  &kt PLUS       &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                       &trans    &trans      &trans         &trans          &trans         &trans
@@ -69,7 +69,7 @@
 
         raise_layer {
             bindings = <
-&gresc  &kp F1        &kp F2        &kp F3        &kp F4        &kp F5          &kp F6    &kp F7    &kp F8  &kp F9     &kp F10  &mt F11 F12
+&trans  &kp F1        &kp F2        &kp F3        &kp F4        &kp F5          &kp F6    &kp F7    &kp F8  &kp F9     &kp F10  &mt F11 F12
 &trans  &bt BT_CLR    &out OUT_TOG  &none         &none         &none           &kp LEFT  &kp DOWN  &kp UP  &kp RIGHT  &none    &none
 &trans  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &none     &none     &none   &none      &trans   &trans
                                     &trans        &trans        &trans          &trans    &trans    &trans
@@ -78,7 +78,7 @@
 
         adjust_layer {
             bindings = <
-&gresc  &kp N1        &kp N2      &kp N3             &kp N4           &kp N5      &kp N6         &kp N7    &kp N8    &kp N9     &kp N0  &kp BSPC
+&trans  &kp N1        &kp N2      &kp N3             &kp N4           &kp N5      &kp N6         &kp N7    &kp N8    &kp N9     &kp N0  &kp BSPC
 &trans  &none         &kp C_PREV  &kp C_PLAY_PAUSE   &kp C_NEXT       &kp HOME    &kp PAGE_UP    &none     &kp UP    &none      &none   &none
 &trans  &kp CAPSLOCK  &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp END     &kp PAGE_DOWN  &kp LEFT  &kp DOWN  &kp RIGHT  &none   &trans
                                   &trans             &trans           &trans      &trans         &trans    &trans


### PR DESCRIPTION
- 修改“corne.keymap”文件
- 在“lower_layer”和“raise_layer”中添加“&#43;”和“trans”的绑定
- 在“adjust_layer”中添加“&#43;”和“trans”的绑定

Signed-off-by: DAST-HomePC <jackie@dast.tw>
