### PR TITLE
風格：更新按鍵映射以使用 LGUI&#43;mo LOWER 而不是 LGUI&#43;mo 1 來切換到 LOWER 層。

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -71,10 +71,10 @@
 
         base_layer {
             bindings = <
-&gresc      &kp Q  &kp W  &kp E     &kp R  &kp T               &kp Y    &kp U           &kp I       &kp O    &kp P     &kp NON_US_BACKSLASH
-&kp LCTRL   &kp A  &kp S  &kp D     &kp F  &kp G               &kp H    &kp J           &kp K       &kp L    &kp SEMI  &kp SQT
-&kp LSHIFT  &kp Z  &kp X  &kp C     &kp V  &kp B               &kp N    &kp M           &kp COMMA   &kp DOT  &kp FSLH  &kp RALT
-                          &kp LGUI  &mo 1  &mt LSHIFT SPACE    &kp RET  &lt RAISE BSPC  &spotlight
+&gresc      &kp Q  &kp W  &kp E     &kp R      &kp T               &kp Y    &kp U           &kp I       &kp O    &kp P     &kp NON_US_BACKSLASH
+&kp LCTRL   &kp A  &kp S  &kp D     &kp F      &kp G               &kp H    &kp J           &kp K       &kp L    &kp SEMI  &kp SQT
+&kp LSHIFT  &kp Z  &kp X  &kp C     &kp V      &kp B               &kp N    &kp M           &kp COMMA   &kp DOT  &kp FSLH  &kp RALT
+                          &kp LGUI  &mo LOWER  &mt LSHIFT SPACE    &kp RET  &lt RAISE BSPC  &spotlight
             >;
         };
 


### PR DESCRIPTION
- 更新按鍵映射，以 LGUI&#43;mo LOWER 取代 LGUI&#43;mo 1 來切換到 LOWER 層

Signed-off-by: DAST-HomePC <jackie@dast.tw>
