### PR TITLE
工作：從corne.keymap文件中刪除不必要的HTML編碼

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -59,11 +59,6 @@
             #binding-cells = <0>;
             mods = <(MOD_LGUI)>;
         };
-
-        &lt {
-            tapping-term-ms = <200>;
-            flavor = "hold-preferred";
-        };
     };
 
     keymap {


### PR DESCRIPTION
- 從corne.keymap文件中刪除`&amp;amp;lt`區塊

Signed-off-by: DAST-HomePC <jackie@dast.tw>
