### PR TITLE
重構：重構踢躂舞行為標籤

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -7,7 +7,6 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/outputs.h>
 
 #define BASE     0
@@ -62,14 +61,13 @@
             compatible = "zmk,behavior-mod-morph";
             label = "TAB_TILDE";
             bindings = <&kp TAB>, <&kp TILDE>;
-
             #binding-cells = <0>;
             mods = <(MOD_LGUI)>;
         };
 
-        td_multi: tap_dance_multi {
+        td_multi_gui: tap_dance_multi_gui {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI";
+            label = "TAP_DANCE_MULTI_GUI";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp LGUI>, <&spotlight>;
@@ -91,19 +89,19 @@
 
         base_layer {
             bindings = <
-&tab_tilde  &kp Q  &kp W  &kp E      &kp R      &kp T               &kp Y    &kp U           &kp I         &kp O    &kp P     &kp NUBS
-&kp LCTRL   &kp A  &kp S  &kp D      &kp F      &kp G               &kp H    &kp J           &kp K         &kp L    &kp SEMI  &kp SQT
-&kp LSHIFT  &kp Z  &kp X  &kp C      &kp V      &kp B               &kp N    &kp M           &kp COMMA     &kp DOT  &kp FSLH  &kp RALT
-                          &td_multi  &mo LOWER  &sm LSHIFT SPACE    &kp RET  &lt RAISE BSPC  &mo FUNCTION
+&tab_tilde  &kp Q  &kp W  &kp E          &kp R      &kp T               &kp Y    &kp U           &kp I         &kp O    &kp P     &kp NUBS
+&kp LCTRL   &kp A  &kp S  &kp D          &kp F      &kp G               &kp H    &kp J           &kp K         &kp L    &kp SEMI  &kp SQT
+&kp LSHIFT  &kp Z  &kp X  &kp C          &kp V      &kp B               &kp N    &kp M           &kp COMMA     &kp DOT  &kp FSLH  &kp RALT
+                          &td_multi_gui  &mo LOWER  &sm LSHIFT SPACE    &kp RET  &lt RAISE BSPC  &mo FUNCTION
             >;
         };
 
         lower_layer {
             bindings = <
-&tab_tilde  &kp EXCLAMATION  &kp AT  &kp HASH   &kp DOLLAR  &kp PERCENT         &kp CARET  &kp AMPERSAND   &kp STAR      &kp LPAR  &kp RPAR  &kp NUBS
-&kp LCTRL   &kp N1           &kp N2  &kp N3     &kp N4      &kp N5              &kp MINUS  &kp EQUAL       &kp GRAVE     &kp LBKT  &kp RBKT  &kp PIPE
-&kp LSHIFT  &kp N6           &kp N7  &kp N8     &kp N9      &kp N0              &kp UNDER  &kt PLUS        &kp TILDE     &kp LBRC  &kp RBRC  &kp RALT
-                                     &td_multi  &trans      &sm LSHIFT SPACE    &kp RET    &lt RAISE BSPC  &mo FUNCTION
+&tab_tilde  &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT         &kp CARET  &kp AMPERSAND   &kp STAR      &kp LPAR  &kp RPAR  &kp NUBS
+&kp LCTRL   &kp N1           &kp N2  &kp N3         &kp N4      &kp N5              &kp MINUS  &kp EQUAL       &kp GRAVE     &kp LBKT  &kp RBKT  &kp PIPE
+&kp LSHIFT  &kp N6           &kp N7  &kp N8         &kp N9      &kp N0              &kp UNDER  &kt PLUS        &kp TILDE     &kp LBRC  &kp RBRC  &kp RALT
+                                     &td_multi_gui  &trans      &sm LSHIFT SPACE    &kp RET    &lt RAISE BSPC  &mo FUNCTION
             >;
         };
 
@@ -112,16 +110,16 @@
 &tab_tilde  &kp N1        &kp N2      &kp N3             &kp N4           &kp N5              &kp N6     &kp N7    &kp N8        &kp N9     &kp N0  &kp BSPC
 &kp LCTRL   &none         &kp C_PREV  &kp C_PLAY_PAUSE   &kp C_NEXT       &kp HOME            &kp PG_UP  &none     &kp UP        &none      &none   &none
 &kp LSHIFT  &kp CAPSLOCK  &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp END             &kp PG_DN  &kp LEFT  &kp DOWN      &kp RIGHT  &none   &kp RALT
-                                      &td_multi          &mo LOWER        &sm LSHIFT SPACE    &kp RET    &trans    &mo FUNCTION
+                                      &td_multi_gui      &mo LOWER        &sm LSHIFT SPACE    &kp RET    &trans    &mo FUNCTION
             >;
         };
 
         function_layer {
             bindings = <
-&tab_tilde  &kp F1        &kp F2        &kp F3        &kp F4        &kp F5              &kp F6    &kp F7            &kp F8        &kp F9     &kp F10  &kp F11
-&kp LCTRL   &bt BT_CLR    &out OUT_TOG  &none         &none         &none               &kp LEFT  &kp DOWN          &kp UP        &kp RIGHT  &none    &kp F12
-&kp LSHIFT  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4        &none     &none             &none         &none      &none    &kp RALT
-                                        &td_multi     &mo LOWER     &sm LSHIFT SPACE    &kp RET   &lt RAISE BSPC    &trans
+&tab_tilde  &kp F1        &kp F2        &kp F3         &kp F4        &kp F5              &kp F6    &kp F7            &kp F8        &kp F9     &kp F10  &kp F11
+&kp LCTRL   &bt BT_CLR    &out OUT_TOG  &none          &none         &none               &kp LEFT  &kp DOWN          &kp UP        &kp RIGHT  &none    &kp F12
+&kp LSHIFT  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4        &none     &none             &none         &none      &none    &kp RALT
+                                        &td_multi_gui  &mo LOWER     &sm LSHIFT SPACE    &kp RET   &lt RAISE BSPC    &trans
             >;
         };
     };


### PR DESCRIPTION
- 移除重複引用的 `dt-bindings/zmk/keys.h`
- 將 `td_multi` 的標籤更改為 `TAP_DANCE_MULTI_GUI`
- 移除帶有標籤 `td_multi` 的行
- 將 `td_multi_gui` 的標籤更改為 `TAP_DANCE_MULTI_GUI`
- 移除帶有標籤 `td_multi_gui` 的行
- 將 `tap_dance_multi_gui` 行為的標籤更改為 `TAP_DANCE_MULTI_GUI`
- 移除帶有標籤 `tap_dance_multi_gui` 的行
- 移除帶有標籤 `td_multi_gui` 的行
- 移除帶有標籤 `TAP_DANCE_MULTI_GUI` 的行
- 移除帶有標籤 `tap_dance_multi` 的行
- 移除帶有標籤 `td_multi` 的行
- 移除帶有標籤 `TAP_DANCE_MULTI` 的行

Signed-off-by: DAST-HomePC <jackie@dast.tw>
