### PR TITLE
任務：更新數字鍵盤和功能鍵的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -107,10 +107,10 @@
 
         raise_layer {
             bindings = <
-&tab_tilde  &kp N1        &kp N2      &kp N3             &kp N4           &kp N5              &kp N6     &kp N7    &kp N8        &kp N9     &kp N0  &kp BSPC
-&kp LCTRL   &none         &kp C_PREV  &kp C_PLAY_PAUSE   &kp C_NEXT       &kp HOME            &kp PG_UP  &none     &kp UP        &none      &none   &none
-&kp LSHIFT  &kp CAPSLOCK  &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp END             &kp PG_DN  &kp LEFT  &kp DOWN      &kp RIGHT  &none   &kp RALT
-                                      &td_multi_gui      &mo LOWER        &sm LSHIFT SPACE    &kp RET    &trans    &mo FUNCTION
+&tab_tilde  &kp N1        &kp N2      &kp N3         &kp N4        &kp N5              &kp N6     &kp N7    &kp N8        &kp N9     &kp N0  &kp BSPC
+&kp LCTRL   &none         &kp C_PREV  &kp C_PP       &kp C_NEXT    &kp HOME            &kp PG_UP  &none     &kp UP        &none      &none   &none
+&kp LSHIFT  &kp CAPSLOCK  &kp C_MUTE  &kp C_VOL_DN   &kp C_VOL_UP  &kp END             &kp PG_DN  &kp LEFT  &kp DOWN      &kp RIGHT  &none   &kp RALT
+                                      &td_multi_gui  &mo LOWER     &sm LSHIFT SPACE    &kp RET    &trans    &mo FUNCTION
             >;
         };
 


### PR DESCRIPTION
- 將 `tab_tilde` 和 `kp N1` 的按鍵綁定更新為 `kp N0`
- 將 `kp LCTRL` 的按鍵綁定更新為 `kp C_PREV`、`kp C_PLAY_PAUSE` 和 `kp C_NEXT`
- 將 `kp LSHIFT` 的按鍵綁定更新為 `kp CAPSLOCK`、`kp C_VOLUME_DOWN` 和 `kp C_VOLUME_UP`
- 將 `td_multi_gui` 的按鍵綁定更新為 `mo LOWER`、`sm LSHIFT SPACE`、`kp RET`、`trans` 和 `mo FUNCTION`

Signed-off-by: DAST-HomePC <jackie@dast.tw>
