### PR TITLE
事務: 更新 corne.keymap 的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -83,7 +83,7 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E          &kp R      &kp T                   &kp Y      &kp U                &kp I         &kp O       &kp P          &kp NON_US_BACKSLASH
 &kp LEFT_CONTROL  &kp A  &kp S  &kp D          &kp F      &kp G                   &kp H      &kp J                &kp K         &kp L       &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_SHIFT    &kp Z  &kp X  &kp C          &kp V      &kp B                   &kp N      &kp M                &kp COMMA     &kp PERIOD  &kp SLASH      &kp RIGHT_ALT
+&kp LEFT_SHIFT    &kp Z  &kp X  &kp C          &kp V      &kp B                   &kp N      &kp M                &kp COMMA     &kp PERIOD  &kp SLASH      &kp LEFT_ALT
                                 &td_multi_gui  &mo LOWER  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt RAISE BACKSPACE  &mo FUNCTION
             >;
         };
@@ -92,7 +92,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND        &kp STAR      &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &kp LEFT_CONTROL  &kp N1           &kp N2  &kp N3         &kp N4      &kp N5                  &kp MINUS       &kp EQUAL            &kp GRAVE     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_SHIFT    &kp N6           &kp N7  &kp N8         &kp N9      &kp N0                  &kp UNDERSCORE  &kt PLUS             &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp RIGHT_ALT
+&kp LEFT_SHIFT    &kp N6           &kp N7  &kp N8         &kp N9      &kp N0                  &kp UNDERSCORE  &kt PLUS             &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                            &td_multi_gui  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt RAISE BACKSPACE  &mo FUNCTION
             >;
         };
@@ -101,7 +101,7 @@
             bindings = <
 &kp TAB           &kp N1        &kp N2      &kp N3         &kp N4        &kp N5                  &kp N6     &kp N7    &kp N8        &kp N9     &kp N0  &kp BACKSPACE
 &kp LEFT_CONTROL  &none         &kp C_PREV  &kp C_PP       &kp C_NEXT    &kp HOME                &kp PG_UP  &none     &kp UP        &none      &none   &none
-&kp LEFT_SHIFT    &kp CAPSLOCK  &kp C_MUTE  &kp C_VOL_DN   &kp C_VOL_UP  &kp END                 &kp PG_DN  &kp LEFT  &kp DOWN      &kp RIGHT  &none   &kp RIGHT_ALT
+&kp LEFT_SHIFT    &kp CAPSLOCK  &kp C_MUTE  &kp C_VOL_DN   &kp C_VOL_UP  &kp END                 &kp PG_DN  &kp LEFT  &kp DOWN      &kp RIGHT  &none   &kp LEFT_ALT
                                             &td_multi_gui  &mo LOWER     &sm LEFT_SHIFT SPACE    &kp ENTER  &trans    &mo FUNCTION
             >;
         };
@@ -110,7 +110,7 @@
             bindings = <
 &kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6     &kp F7               &kp F8  &kp F9     &kp F10  &kp F11
 &kp LEFT_CONTROL  &bt BT_CLR    &out OUT_TOG  &none          &none         &none                   &kp LEFT   &kp DOWN             &kp UP  &kp RIGHT  &none    &kp F12
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &none      &none                &none   &none      &none    &kp RIGHT_ALT
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &none      &none                &none   &none      &none    &kp LEFT_ALT
                                               &td_multi_gui  &mo LOWER     &sm LEFT_SHIFT SPACE    &kp ENTER  &lt RAISE BACKSPACE  &trans
             >;
         };


### PR DESCRIPTION
- 修改了檔案 `config/corne.keymap`
- 更改了 `base_layer`、`lower_layer`、`raise_layer` 和 `function_layer` 的綁定
- 添加或移除了多個按鍵和修改器的綁定，例如 `TAB`、`LEFT_CONTROL`、`LEFT_SHIFT` 和功能鍵 `F1` 到 `F12`
- 更改了 `td_multi_gui` 和 `sm` 鍵的綁定
- 添加或移除了特殊按鍵的綁定，如 `BACKSPACE`、`ENTER`、`UP`、`DOWN`、`LEFT`、`RIGHT`、`CAPSLOCK`、`NON_US_BACKSLASH`、`APOSTROPHE`、`COMMA`、`PERIOD`、`SLASH`、`LEFT_BRACE`、`RIGHT_BRACE`、`GRAVE`、`LEFT_BRACKET`、`RIGHT_BRACKET`、`PIPE`、`TILDE`、`EQUAL`、`UNDERSCORE`、`PLUS`、`MINUS`
- 更改了媒體按鍵的綁定，如 `C_MUTE`、`C

Signed-off-by: DAST-HomePC <jackie@dast.tw>
