### PR TITLE
工作：更新 `td_multi_mac` 和 `windows_default_layer` 的綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -76,7 +76,7 @@
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&spotlight>/ ;
+            bindings = <&kp LGUI>, <&spotlight>;
         };
 
         td_multi_win: tap_dance_multi_win {
@@ -139,27 +139,27 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U                &kp I         &kp O      &kp P          &kp NON_US_BACKSLASH
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J                &kp K         &kp L      &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL ================================== &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M                &kp COMMA     &kp TILDE  &kp PERIOD     &kp SLASH
-                                &kp LEFT_ALT   &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I          &kp O      &kp P          &kp NON_US_BACKSLASH
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K          &kp L      &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA      &kp TILDE  &kp PERIOD     &kp SLASH
+                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR      &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &kp MINUS       &kp EQUAL              &kp GRAVE     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &kt PLUS               &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp ESC
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR       &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &kp MINUS       &kp EQUAL              &kp GRAVE      &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &kt PLUS               &kp TILDE      &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp ESC
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0  &kp BACKSPACE
-&kp LEFT_SHIFT    &kp CAPSLOCK  &none         &none         &none         &kp HOME                &kp PAGE_UP    &none         &kp UP        &none         &none         &none
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &kp LEFT      &kp DOWN      &kp RIGHT     &none         &kp ESC
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0  &kp BACKSPACE
+&kp LEFT_SHIFT    &kp CAPSLOCK  &none         &none         &none         &kp HOME                &kp PAGE_UP    &none         &kp UP         &none         &none         &none
+&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &kp LEFT      &kp DOWN       &kp RIGHT     &none         &kp ESC
                                               &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
         };


### PR DESCRIPTION
- 移除 `td_multi_mac` 的 `bindings` 行的尾端斜線
- 將 `bindings` 行的 `td_multi_mac` 修改為包含 `&amp;lt;&amp;amp;spotlight&amp;gt;` 而非 `&amp;lt;&amp;amp;spotlight&amp;gt;/`
- 將 `bindings` 行的 `windows_default_layer` 修改為包含 `&amp;amp;kp LEFT_CONTROL` 而非 `&amp;amp;kp LEFT_CONTROL ==================================`
- 移除 `windows_default_layer` 的 `bindings` 行的尾端斜線
- 將 `bindings` 行的 `windows_code_layer` 修改為包含 `&amp;amp;kp LEFT_CONTROL` 而非 `&amp;amp;kp LEFT_CONTROL ==================================`

Signed-off-by: DAST-HomePC <jackie@dast.tw>
