### PR TITLE
風格：更新左 GUI 鍵的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -46,9 +46,7 @@
             #binding-cells = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LGUI>,
-                <&macro_press>,
-                <&kp LEFT_SHIFT>,
+                <&kp LGUI &kp LEFT_SHIFT>,
                 <&macro_tap>,
                 <&kp S>,
                 <&macro_release>,


### PR DESCRIPTION
- 刪除 `&amp;lt;&amp;amp;kp LGUI&amp;gt;` 的鍵綁定並替換為 `&amp;lt;&amp;amp;kp LGUI &amp;amp;kp LEFT_SHIFT&amp;gt;`

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
