### PR TITLE
功能: 更新 corne.keymap 文件中的按键绑定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -32,12 +32,9 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LGUI>,
-                <&macro_tap>,
-                <&kp SPACE>,
-                <&macro_release>,
-                <&kp LGUI>;
+                <&macro_press &kp LGUI>,
+                <&macro_tap &kp SPACE>,
+                <&macro_release &kp LGUI>;
         };
 
         screenshot: screenshot {
@@ -45,12 +42,9 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LGUI &kp LEFT_SHIFT>,
-                <&macro_tap>,
-                <&kp S>,
-                <&macro_release>,
-                <&kp LGUI &kp LEFT_SHIFT>;
+                <&macro_press &kp LGUI &kp LEFT_SHIFT>,
+                <&macro_tap &kp S>,
+                <&macro_release &kp LGUI &kp LEFT_SHIFT>;
         };
     };
 


### PR DESCRIPTION
- 从 corne.keymap 文件中移除 "kp SPACE" 绑定
- 在 corne.keymap 文件中添加 "macro_press kp LGUI"、"macro_tap kp SPACE" 和 "macro_release kp LGUI" 绑定

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
