### PR TITLE
功能: 在corne.keymap配置中添加截图和双击舞蹈行为宏

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -37,13 +37,23 @@
                 <&macro_release &kp LGUI>;
         };
 
-        screenshot: screenshot {
-            label = "screenshot";
+        screenshot_win: screenshot_win {
+            label = "SCREENSHOT_WIN";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
                 <&macro_press &kp LGUI &kp LEFT_SHIFT>,
                 <&macro_tap &kp S>,
+                <&macro_release &kp LGUI &kp LEFT_SHIFT>;
+        };
+
+        screenshot_mac: screenshot_mac {
+            label = "SCREEMSHOT_MAC";
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings =
+                <&macro_press &kp LGUI &kp LEFT_SHIFT>,
+                <&macro_tap &kp NUMBER_4>,
                 <&macro_release &kp LGUI &kp LEFT_SHIFT>;
         };
     };
@@ -68,7 +78,7 @@
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&spotlight>, <&kp ESCAPE>;
+            bindings = <&kp LGUI>, <&spotlight>, <&screenshot_mac>;
         };
 
         td_multi_win: tap_dance_multi_win {
@@ -76,7 +86,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&screenshot>, <&kp ESCAPE>;
+            bindings = <&kp LGUI>, <&screenshot_win>, <&kp ESCAPE>;
         };
 
         sm: space_mod {


### PR DESCRIPTION
- 在corne.keymap配置中添加`screenshot_win`行为宏
- 在corne.keymap配置中添加`screenshot_mac`行为宏
- 更新corne.keymap配置中`screenshot`行为宏的绑定
- 更新corne.keymap配置中`tap_dance_multi_mac`组合键的绑定
- 更新corne.keymap配置中`tap_dance_multi_win`组合键的绑定

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
