### PR TITLE
工作：重構 Windows 和 macOS 的鍵盤映射綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -151,10 +151,10 @@
 
         windows_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6            &kp F7                 &kp F8             &kp F9      &kp F10     &kp F11
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp K_MUTE        &kp C_VOLUME_UP        &kp C_VOLUME_DOWN  &kp K_NEXT  &kp K_PREV  &to MAC
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp K_PLAY_PAUSE  &none                  &none              &none       &kp F12     &bm LC(LEFT_SHIFT) BACKSPACE
-                                              &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER         &lt WIN_NUM BACKSPACE  &td_multi_win
+&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6            &kp F7           &kp F8             &kp F9      &kp F10     &kp F11
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp K_MUTE        &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &kp K_NEXT  &kp K_PREV  &to MAC
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp K_PLAY_PAUSE  &none            &none              &none       &kp F12     &bm LC(LEFT_SHIFT) BACKSPACE
+                                              &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER         &trans           &td_multi_win
             >;
         };
 
@@ -187,10 +187,10 @@
 
         mac_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6            &kp F7                 &kp F8             &kp F9      &kp F10     &kp F11
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &kp K_MUTE        &kp C_VOLUME_UP        &kp C_VOLUME_DOWN  &kp K_NEXT  &kp K_PREV  &to WINDOWS
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp K_PLAY_PAUSE  &none                  &none              &none       &kp F12     &bm LC(LEFT_SHIFT) BACKSPACE
-                                              &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER         &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
+&kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6            &kp F7           &kp F8             &kp F9      &kp F10     &kp F11
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &kp K_MUTE        &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &kp K_NEXT  &kp K_PREV  &to WINDOWS
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp K_PLAY_PAUSE  &none            &none              &none       &kp F12     &bm LC(LEFT_SHIFT) BACKSPACE
+                                              &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER         &trans           &kp LEFT_ALT
             >;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -108,9 +108,9 @@
             bindings = <&kp>, <&kp>;
         };
 
-        em: enter_mod {
+        bm: backspace_mod {
             compatible = "zmk,behavior-hold-tap";
-            label = "ENTER_MOD";
+            label = "BACKSPACE_MOD";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <200>;
@@ -126,7 +126,7 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I          &kp O    &kp P          &kp MINUS
 &kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &bm LC(LEFT_SHIFT) BACKSPACE
                                 &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };
@@ -135,7 +135,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR       &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &kp MINUS       &kp EQUAL              &kp GRAVE      &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &kt PLUS               &kp TILDE      &kp LEFT_BRACE        &kp RIGHT_BRACE        &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &kt PLUS               &kp TILDE      &kp LEFT_BRACE        &kp RIGHT_BRACE        &bm LC(LEFT_SHIFT) BACKSPACE
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };
@@ -143,8 +143,8 @@
         windows_number_layer {
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0  &kp BACKSPACE
-&kp LEFT_SHIFT    &kp CAPSLOCK  &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT     &none
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none         &none          &none         &none         &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_SHIFT    &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT     &none
+&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none         &none          &none         &none         &bm LC(LEFT_SHIFT) BACKSPACE
                                               &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
         };
@@ -153,7 +153,7 @@
             bindings = <
 &kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6            &kp F7                 &kp F8             &kp F9      &kp F10     &kp F11
 &kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp K_MUTE        &kp C_VOLUME_UP        &kp C_VOLUME_DOWN  &kp K_NEXT  &kp K_PREV  &to MAC
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp K_PLAY_PAUSE  &none                  &none              &none       &kp F12     &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp K_PLAY_PAUSE  &none                  &none              &none       &kp F12     &bm LC(LEFT_SHIFT) BACKSPACE
                                               &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER         &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };
@@ -162,7 +162,7 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U                  &kp I         &kp O    &kp P          &kp MINUS
 &kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J                  &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M                  &kp COMMA     &kp DOT  &kp SLASH      &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M                  &kp COMMA     &kp DOT  &kp SLASH      &bm LC(LEFT_SHIFT) BACKSPACE
                                 &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
         };
@@ -171,7 +171,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR      &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &kp LEFT_SHIFT    &none            &none   &none          &none       &none                   &kp MINUS       &kp EQUAL              &kp GRAVE     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp UNDERSCORE  &kt PLUS               &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp UNDERSCORE  &kt PLUS               &kp TILDE     &kp LEFT_BRACE        &kp RIGHT_BRACE        &bm LC(LEFT_SHIFT) BACKSPACE
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
         };
@@ -179,8 +179,8 @@
         mac_number_layer {
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0  &kp BACKSPACE
-&kp LEFT_SHIFT    &kp CAPSLOCK  &none         &none          &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &none
-&kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &none         &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_SHIFT    &none         &none         &none          &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &none
+&kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &none         &bm LC(LEFT_SHIFT) BACKSPACE
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
         };
@@ -189,7 +189,7 @@
             bindings = <
 &kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6            &kp F7                 &kp F8             &kp F9      &kp F10     &kp F11
 &kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &kp K_MUTE        &kp C_VOLUME_UP        &kp C_VOLUME_DOWN  &kp K_NEXT  &kp K_PREV  &to WINDOWS
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp K_PLAY_PAUSE  &none                  &none              &none       &kp F12     &em LC(LEFT_SHIFT) ENTER
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp K_PLAY_PAUSE  &none                  &none              &none       &kp F12     &bm LC(LEFT_SHIFT) BACKSPACE
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER         &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
         };


### PR DESCRIPTION
- 修改 `config/corne.keymap` 中 `windows_function_layer` 和 `mac_function_layer` 的綁定
- 將 `&amp;lt` 和 `&amp;gt` 符號改為 `&amp;amp;trans`，用於 `windows_function_layer` 和 `mac_function_layer`
- 從 `windows_function_layer` 和 `mac_function_layer` 中刪除 `&amp;amp;kp LEFT_ALT` 的綁定
- 在 `windows_function_layer` 中使用 `&amp;amp;trans` 替換 `&amp;amp;mo WIN_CODE`
- 在 `mac_function_layer` 中使用 `&amp;amp;trans` 替換 `&amp;amp;mo MAC_CODE`
- 從 `windows_function_layer` 中刪除 `&amp;amp;lt WIN_NUM BACKSPACE` 的綁定
- 從 `mac_function_layer` 中刪除 `&amp;amp;lt MAC_NUM BACKSPACE` 的綁定
- 調整 `config/corne.keymap` 中修改綁定的行數

Signed-off-by: DAST-HomePC <jackie@dast.tw>
