### PR TITLE
功能: 更新 `corne` 配置文件的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -124,10 +124,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I          &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &bm LC(LEFT_SHIFT) BACKSPACE
-                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
+&kp TAB           &kp Q  &kp W  &kp E         &kp R              &kp T                   &kp Y      &kp U                  &kp I          &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F              &kp G                   &kp H      &kp J                  &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V              &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &bm LC(LEFT_SHIFT) BACKSPACE
+                                &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };
 
@@ -142,10 +142,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0  &kp BACKSPACE
-&kp LEFT_SHIFT    &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT     &none
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none         &none          &none         &none         &bm LC(LEFT_SHIFT) BACKSPACE
-                                              &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0  &kp BACKSPACE
+&kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT     &none
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &none         &bm LC(LEFT_SHIFT) BACKSPACE
+                                              &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
         };
 


### PR DESCRIPTION
- 修改 `corne` 配置文件的按鍵映射
- 將 `kp LEFT_ALT` 的鍵綁定更改為包括 `lt WIN_CODE LGUI`
- 更新 `kp ENTER` 的鍵綁定以包括 `&amp;trans`
- 文件中沒有其他相關更改

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
