### PR TITLE
事務：在「corne.keymap」中更新「td_multi_win」的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -122,7 +122,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&kp LG(Q)>, <&screenshot_win>;
+            bindings = <&kp LGUI>, <&kp LG(C)>, <&screenshot_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {


### PR DESCRIPTION
- 修改「corne.keymap」檔案中「td_multi_win」的鍵綁定，從「LGUI, LG(Q), screenshot_win」變更為「LGUI, LG(C), screenshot_win」。

Signed-off-by: DAST-HomePC <jackie@dast.tw>
