### PR TITLE
工作：更新截圖功能的按鍵映射

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -39,7 +39,7 @@
                 <&macro_release>,
                 <&kp LGUI>,
                 <&macro_tap>,
-                <&kp W &kp T &kp ENTER>;
+                <&kp BACKSPACE &kp W &kp T &kp ENTER>;
         };
 
         screenshot_win: screenshot_win {


### PR DESCRIPTION
- 修改 `screenshot_win` 功能的按鍵映射，將序列 `&lt;kp W T ENTER&gt;` 替換為 `&lt;kp BACKSPACE W T ENTER&gt;`。

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
