### PR TITLE
工作：更新截圖功能的按鍵映射

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -27,8 +27,8 @@
 
 / {
     macros {
-        calculator: calculator {
-            label = "CALCULATOR";
+        windows_terminal: windows_terminal {
+            label = "WINDOWS_TERMINAL";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
@@ -39,7 +39,7 @@
                 <&macro_release>,
                 <&kp LGUI>,
                 <&macro_tap>,
-                <&kp C &kp A &kp L &kp C &kp ENTER>;
+                <&kp W &kp T &kp ENTER>;
         };
 
         screenshot_win: screenshot_win {
@@ -168,7 +168,7 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R              &kp T                   &kp Y      &kp U                  &kp I          &kp O    &kp P          &kp MINUS
 &kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F              &kp G                   &kp H      &kp J                  &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V              &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &calculator
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V              &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &windows_terminal
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -39,7 +39,7 @@
                 <&macro_release>,
                 <&kp LGUI>,
                 <&macro_tap>,
-                <&kp W &kp T &kp ENTER>;
+                <&kp BACKSPACE &kp W &kp T &kp ENTER>;
         };
 
         screenshot_win: screenshot_win {


### PR DESCRIPTION
- 修改 `screenshot_win` 功能的按鍵映射，將序列 `&lt;kp W T ENTER&gt;` 替換為 `&lt;kp BACKSPACE W T ENTER&gt;`。

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
