### PR TITLE
工作：交換鍵盤映射的順序

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -161,7 +161,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&terminal_win>, <&screenshot_win>;
+            bindings = <&kp LGUI>, <&screenshot_win>, <&terminal_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {
@@ -169,7 +169,7 @@
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&spotlight>, <&screenshot_mac>;
+            bindings = <&kp LGUI>, <&screenshot_mac>, <&spotlight>;
         };
 
         sm: space_mod {


### PR DESCRIPTION
- 在 `config/corne.keymap` 檔案中，交換 `td_multi_win` 和 `td_multi_mac` 的映射順序。

Signed-off-by: DAST-HomePC <jackie@dast.tw>
