### PR TITLE
工作: 更新 Windows 和 Mac 的按鍵映射檔案標籤

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -194,7 +194,7 @@
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
-            label = "WIN_DEF";
+            label = "WINDOWS";
         };
 
         windows_code_layer {
@@ -238,7 +238,7 @@
                                 &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
-            label = "MAC_DEF";
+            label = "MAC";
         };
 
         mac_code_layer {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -193,6 +193,8 @@
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V              &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &kp EQUAL
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
+
+            label = "WIN_DEF";
         };
 
         windows_code_layer {
@@ -202,6 +204,8 @@
 &kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
+
+            label = "WIN_CODE";
         };
 
         windows_number_layer {
@@ -211,6 +215,8 @@
 &kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
+
+            label = "WIN_NUM";
         };
 
         windows_function_layer {
@@ -220,6 +226,8 @@
 &kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp C_PP   &kp C_NEXT  &kp C_PREV         &none            &none         &none
                                               &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &td_multi_win
             >;
+
+            label = "WIN_FUNC";
         };
 
         mac_default_layer {
@@ -229,6 +237,8 @@
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M                  &kp COMMA     &kp DOT  &kp SLASH      &kp EQUAL
                                 &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
+
+            label = "MAC_DEF";
         };
 
         mac_code_layer {
@@ -238,6 +248,8 @@
 &kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp UNDERSCORE  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
+
+            label = "MAC_CODE";
         };
 
         mac_number_layer {
@@ -247,6 +259,8 @@
 &kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &kp LC(LEFT_SHIFT)  &sk GLOBE
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
+
+            label = "MAC_NUM";
         };
 
         mac_function_layer {
@@ -256,6 +270,8 @@
 &kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp C_PP   &kp C_NEXT  &kp C_PREV         &none            &none    &none
                                               &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &kp LEFT_ALT
             >;
+
+            label = "MAC_FUNC";
         };
 
         game_default_layer {
@@ -265,6 +281,8 @@
 &kp LEFT_SHIFT    &kp Z  &none  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
                                 &kp NUMBER_1  &mo GAME_OPT  &kp SPACE       &none  &none  &none
             >;
+
+            label = "GAME";
         };
 
         game_option_layer {
@@ -274,6 +292,8 @@
 &kp G   &none         &kp F4        &kp F1        &kp F3        &kp B           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
+
+            label = "GAME_OPT";
         };
     };
 


### PR DESCRIPTION
- 在 corne.keymap 檔案中，將 &#34;WIN_DEF&#34; 的標籤更改為 &#34;WINDOWS&#34;
- 在 corne.keymap 檔案中，將 &#34;MAC_DEF&#34; 的標籤更改為 &#34;MAC&#34;

Signed-off-by: Macbook <jackie@dast.tw>
