### PR TITLE
重構: 更新程式碼層、數字層和功能層的標籤名稱

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -194,7 +194,7 @@
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
-            label = "WINDOWS";
+            label = "WIN";
         };
 
         windows_code_layer {
@@ -205,7 +205,7 @@
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
-            label = "WIN_CODE";
+            label = "WIN_C";
         };
 
         windows_number_layer {
@@ -216,7 +216,7 @@
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 
-            label = "WIN_NUM";
+            label = "WIN_N";
         };
 
         windows_function_layer {
@@ -227,7 +227,7 @@
                                               &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &td_multi_win
             >;
 
-            label = "WIN_FUNC";
+            label = "WIN_F";
         };
 
         mac_default_layer {
@@ -249,7 +249,7 @@
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
-            label = "MAC_CODE";
+            label = "MAC_C";
         };
 
         mac_number_layer {
@@ -260,7 +260,7 @@
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
 
-            label = "MAC_NUM";
+            label = "MAC_N";
         };
 
         mac_function_layer {
@@ -271,7 +271,7 @@
                                               &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &kp LEFT_ALT
             >;
 
-            label = "MAC_FUNC";
+            label = "MAC_F";
         };
 
         game_default_layer {
@@ -293,7 +293,7 @@
                                     &none         &trans        &trans          &none  &none  &none
             >;
 
-            label = "GAME_OPT";
+            label = "GAME2";
         };
     };
 


### PR DESCRIPTION
- 將 `windows_code_layer` 的標籤從 "WINDOWS" 更改為 "WIN"
- 將 `windows_number_layer` 的標籤從 "WIN_NUM" 更改為 "WIN_N"
- 將 `windows_function_layer` 的標籤從 "WIN_FUNC" 更改為 "WIN_F"
- 將 `mac_default_layer` 的標籤從 "MAC_CODE" 更改為 "MAC_C"
- 將 `mac_number_layer` 的標籤從 "MAC_NUM" 更改為 "MAC_N"
- 將 `mac_function_layer` 的標籤從 "MAC_FUNC" 更改為 "MAC_F"
- 將 `game_default_layer` 的標籤從 "GAME_OPT" 更改為 "GAME2"

請確保翻譯符合程式設計師共識，並保持格式不變。

Signed-off-by: DAST-HomePC <jackie@dast.tw>
