### PR TITLE
重構：更新 Windows 數字層綁定和標籤

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -212,7 +212,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &kp C_PWR
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 


### PR DESCRIPTION
- 修改「kp LEFT_CONTROL」的「windows_number_layer」綁定，包括「&amp;kp C_PWR」
- 將「windows_number_layer」的標籤從「&#34;WIN_N&#34;」變更為「&#34;WIN_N&#34;」

Signed-off-by: DAST-HomePC <jackie@dast.tw>
