### PR TITLE
feature

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -199,10 +199,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &none           &none                  &none          &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
-                                           &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
+&kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &none      &none                  &none          &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &none      &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+                                           &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
             label = "WIN_C";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -243,10 +243,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none          &none       &none                   &none           &none                  &none         &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp UNDERSCORE  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
-                                           &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
+&kp LEFT_SHIFT    &none            &none   &none          &none       &none                   &none      &none                  &none         &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &none      &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+                                           &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
             label = "MAC_C";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -201,7 +201,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
 &kp LEFT_SHIFT    &none            &none   &none         &none       &kp CAPSLOCK            &kp INSERT       &none                  &none          &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp PAUSE_BREAK  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+&kp LEFT_CONTROL  &none            &none   &none         &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
@@ -245,7 +245,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
 &kp LEFT_SHIFT    &none            &none   &none          &none       &kp CAPSLOCK            &kp INSERT       &none                  &none         &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp PAUSE_BREAK  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+&kp LEFT_CONTROL  &none            &none   &none          &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -199,10 +199,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &none      &none                  &none          &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &none      &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
-                                           &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
+&kp LEFT_SHIFT    &none            &none   &none         &none       &kp CAPSLOCK            &kp INSERT       &none                  &none          &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp PAUSE_BREAK  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+                                           &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
             label = "WIN_C";
@@ -243,10 +243,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none          &none       &none                   &none      &none                  &none         &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &none      &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
-                                           &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
+&kp LEFT_SHIFT    &none            &none   &none          &none       &kp CAPSLOCK            &kp INSERT       &none                  &none         &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp PAUSE_BREAK  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+                                           &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
             label = "MAC_C";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -212,7 +212,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &kp K_POWER
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 


### PR DESCRIPTION
- 工作: 在`windows_number_layer`中更新`kp LEFT_CONTROL`的鍵綁定
- 工作: 更新 WIN_C 層的按鍵綁定
- 風格：重構鍵綁定和標籤命名以符合Mac的相容性
- 重構：更新 `WIN_C` 和 `MAC_C` 層中 `kp LEFT_SHIFT` 的按鍵綁定
- 工作：更新`config/corne.keymap`中`WIN_C`和`MAC_C`标签的按键绑定
