### PR TITLE
release

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -194,7 +194,7 @@
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
-            label = "WIN_DEF";
+            label = "WINDOWS";
         };
 
         windows_code_layer {
@@ -238,7 +238,7 @@
                                 &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
-            label = "MAC_DEF";
+            label = "MAC";
         };
 
         mac_code_layer {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -277,8 +277,8 @@
         game_default_layer {
             bindings = <
 &kp TAB           &none  &kp Q         &kp W         &kp E         &kp R           &none  &none  &none  &none  &none  &none
-&kp LEFT_CONTROL  &none  &kp A         &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
-&kp LEFT_SHIFT    &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
+&kp LEFT_SHIFT    &none  &kp A         &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
+&kp LEFT_CONTROL  &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
                                        &sk Z         &mo GAME_OPT  &kp SPACE       &none  &none  &none
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -200,8 +200,8 @@
         windows_code_layer {
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none         &none       &kp CAPSLOCK            &kp INSERT       &none                  &none          &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+&kp LEFT_SHIFT    &none            &none   &none         &none       &kp CAPSLOCK            &kp INSERT       &kp APOSTROPHE         &none          &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none         &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &kp DOUBLE_QUOTES      &none          &none     &sk LC(LEFT_SHIFT)    &kp EQUAL
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
@@ -212,7 +212,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &sk LC(LEFT_SHIFT)  &none
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 
@@ -244,8 +244,8 @@
         mac_code_layer {
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none          &none       &kp CAPSLOCK            &kp INSERT       &none                  &none         &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+&kp LEFT_SHIFT    &none            &none   &none          &none       &kp CAPSLOCK            &kp INSERT       &kp APOSTROPHE         &none         &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none          &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &kp DOUBLE_QUOTES      &none         &none     &sk LC(LEFT_SHIFT)    &kp EQUAL
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
@@ -256,7 +256,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none          &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &kp LC(LEFT_SHIFT)  &sk GLOBE
+&kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &sk LC(LEFT_SHIFT)  &sk GLOBE
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -194,7 +194,7 @@
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
-            label = "WINDOWS";
+            label = "WIN";
         };
 
         windows_code_layer {
@@ -205,7 +205,7 @@
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
-            label = "WIN_CODE";
+            label = "WIN_C";
         };
 
         windows_number_layer {
@@ -216,7 +216,7 @@
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 
-            label = "WIN_NUM";
+            label = "WIN_N";
         };
 
         windows_function_layer {
@@ -227,7 +227,7 @@
                                               &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &td_multi_win
             >;
 
-            label = "WIN_FUNC";
+            label = "WIN_F";
         };
 
         mac_default_layer {
@@ -249,7 +249,7 @@
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
-            label = "MAC_CODE";
+            label = "MAC_C";
         };
 
         mac_number_layer {
@@ -260,7 +260,7 @@
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
 
-            label = "MAC_NUM";
+            label = "MAC_N";
         };
 
         mac_function_layer {
@@ -271,7 +271,7 @@
                                               &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &kp LEFT_ALT
             >;
 
-            label = "MAC_FUNC";
+            label = "MAC_F";
         };
 
         game_default_layer {
@@ -293,7 +293,7 @@
                                     &none         &trans        &trans          &none  &none  &none
             >;
 
-            label = "GAME_OPT";
+            label = "GAME2";
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -212,7 +212,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &kp C_PWR
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &kp K_POWER
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -279,7 +279,7 @@
 &kp TAB           &none  &kp Q         &kp W         &kp E         &kp R           &none  &none  &none  &none  &none  &none
 &kp LEFT_CONTROL  &none  &kp A         &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
 &kp LEFT_SHIFT    &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
-                                       &kp Z         &mo GAME_OPT  &kp SPACE       &none  &none  &none
+                                       &sk Z         &mo GAME_OPT  &kp SPACE       &none  &none  &none
             >;
 
             label = "GAME";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -199,10 +199,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none         &none       &none                   &none           &none                  &none          &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
-                                           &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR       &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
+&kp LEFT_SHIFT    &none            &none   &none         &none       &kp CAPSLOCK            &kp INSERT       &none                  &none          &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none         &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+                                           &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
 
             label = "WIN_C";
@@ -212,7 +212,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &kp K_POWER
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 
@@ -243,10 +243,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET       &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
-&kp LEFT_SHIFT    &none            &none   &none          &none       &none                   &none           &none                  &none         &none     &none                 &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp UNDERSCORE  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
-                                           &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR  &kp PERCENT             &kp CARET        &kp AMPERSAND          &kp STAR      &kp PLUS  &kp NON_US_BACKSLASH  &kp MINUS
+&kp LEFT_SHIFT    &none            &none   &none          &none       &kp CAPSLOCK            &kp INSERT       &none                  &none         &none     &none                 &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none          &none       &kp PRINTSCREEN         &kp PAUSE_BREAK  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
+                                           &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER        &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
             label = "MAC_C";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -258,12 +258,12 @@
             >;
         };
 
-        game_mode_layer {
+        game_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp NUMBER_1  &kp W         &kp E         &kp R           &none  &none  &none  &none  &none  &none
-&kp LEFT_CONTROL  &none  &kp A         &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
-&kp LEFT_SHIFT    &kp Z  &none         &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
-                                       &none         &mo GAME_OPT  &kp SPACE       &none  &none  &none
+&kp TAB           &kp Q  &none  &kp W         &kp E         &kp R           &none  &none  &none  &none  &none  &none
+&kp LEFT_CONTROL  &none  &kp A  &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
+&kp LEFT_SHIFT    &kp Z  &none  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
+                                &kp NUMBER_1  &mo GAME_OPT  &kp SPACE       &none  &none  &none
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -193,6 +193,8 @@
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V              &kp B                   &kp N      &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &kp EQUAL
                                 &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
+
+            label = "WIN_DEF";
         };
 
         windows_code_layer {
@@ -202,6 +204,8 @@
 &kp LEFT_CONTROL  &none            &none   &none         &none       &none                   &kp UNDERSCORE  &none                  &none          &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
                                            &kp LEFT_ALT  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt WIN_NUM BACKSPACE  &td_multi_win
             >;
+
+            label = "WIN_CODE";
         };
 
         windows_number_layer {
@@ -211,6 +215,8 @@
 &kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
+
+            label = "WIN_NUM";
         };
 
         windows_function_layer {
@@ -220,6 +226,8 @@
 &kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp C_PP   &kp C_NEXT  &kp C_PREV         &none            &none         &none
                                               &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &td_multi_win
             >;
+
+            label = "WIN_FUNC";
         };
 
         mac_default_layer {
@@ -229,6 +237,8 @@
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M                  &kp COMMA     &kp DOT  &kp SLASH      &kp EQUAL
                                 &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
+
+            label = "MAC_DEF";
         };
 
         mac_code_layer {
@@ -238,6 +248,8 @@
 &kp LEFT_CONTROL  &none            &none   &none          &none       &none                   &kp UNDERSCORE  &none                  &none         &none     &kp LC(LEFT_SHIFT)    &kp EQUAL
                                            &td_multi_mac  &trans      &sm LEFT_SHIFT SPACE    &kp ENTER       &lt MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
+
+            label = "MAC_CODE";
         };
 
         mac_number_layer {
@@ -247,6 +259,8 @@
 &kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &kp LC(LEFT_SHIFT)  &sk GLOBE
                                               &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
+
+            label = "MAC_NUM";
         };
 
         mac_function_layer {
@@ -256,6 +270,8 @@
 &kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp C_PP   &kp C_NEXT  &kp C_PREV         &none            &none    &none
                                               &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &kp LEFT_ALT
             >;
+
+            label = "MAC_FUNC";
         };
 
         game_default_layer {
@@ -265,6 +281,8 @@
 &kp LEFT_SHIFT    &kp Z  &none  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
                                 &kp NUMBER_1  &mo GAME_OPT  &kp SPACE       &none  &none  &none
             >;
+
+            label = "GAME";
         };
 
         game_option_layer {
@@ -274,6 +292,8 @@
 &kp G   &none         &kp F4        &kp F1        &kp F3        &kp B           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
+
+            label = "GAME_OPT";
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -212,7 +212,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4       &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none         &none              &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &none
+&kp LEFT_CONTROL  &none         &none         &none         &none              &kp END                 &kp PAGE_DOWN  &none         &none          &none         &kp LC(LEFT_SHIFT)  &kp C_PWR
                                               &kp LEFT_ALT  &lt WIN_CODE LGUI  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -276,10 +276,10 @@
 
         game_default_layer {
             bindings = <
-&kp TAB           &kp Q  &none  &kp W         &kp E         &kp R           &none  &none  &none  &none  &none  &none
-&kp LEFT_CONTROL  &none  &kp A  &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
-&kp LEFT_SHIFT    &kp Z  &none  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
-                                &kp NUMBER_1  &mo GAME_OPT  &kp SPACE       &none  &none  &none
+&kp TAB           &none  &kp Q         &kp W         &kp E         &kp R           &none  &none  &none  &none  &none  &none
+&kp LEFT_CONTROL  &none  &kp A         &kp S         &kp D         &none           &none  &none  &none  &none  &none  &none
+&kp LEFT_SHIFT    &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none  &none  &none  &none  &none  &none
+                                       &kp Z         &mo GAME_OPT  &kp SPACE       &none  &none  &none
             >;
 
             label = "GAME";
@@ -287,9 +287,9 @@
 
         game_option_layer {
             bindings = <
-&none   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
+&kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
 &trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
-&kp G   &none         &kp F4        &kp F1        &kp F3        &kp B           &none  &none  &none  &none  &none  &none
+&kp G   &none         &kp F4        &kp F1        &kp F3        &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
 


### PR DESCRIPTION
- 工作: 在`windows_number_layer`中更新`kp LEFT_CONTROL`的鍵綁定
- 工作: 更新 WIN_C 層的按鍵綁定
- 風格：重構鍵綁定和標籤命名以符合Mac的相容性
- 重構：更新 `WIN_C` 和 `MAC_C` 層中 `kp LEFT_SHIFT` 的按鍵綁定
- 工作：更新`config/corne.keymap`中`WIN_C`和`MAC_C`标签的按键绑定
- 新增APOS鍵
- 調整上引號鍵位置
- 事務：更新`config`資料夾中的`corne.keymap`文件的按鍵綁定
- 工作：重新配置不同操作系统的键位映射
