### PR TITLE
重構：在不同層級更新 `kp LEFT_ALT` 的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -134,10 +134,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y          &kp U              &kp I          &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H          &kp J              &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N          &kp M              &kp COMMA      &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &lt WIN_NUM ENTER  &td_multi_win
+&kp TAB           &kp Q  &kp W  &kp E         &kp R                   &kp T        &kp Y          &kp U              &kp I          &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F                   &kp G        &kp H          &kp J              &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V                   &kp B        &kp N          &kp M              &kp COMMA      &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &lt WIN_CODE LEFT_SHIFT &kp SPACE    &kp BACKSPACE  &lt WIN_NUM ENTER  &td_multi_win
             >;
 
             label = "Windows";
@@ -148,7 +148,7 @@
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND      &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
 &kp LEFT_SHIFT    &none            &none   &none         &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
 &kp LEFT_CONTROL  &none            &none   &none         &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE     &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
-                                           &kp LEFT_ALT  &trans            &sm LEFT_SHIFT SPACE    &kp BACKSPACE          &lt WIN_NUM ENTER  &td_multi_win
+                                           &kp LEFT_ALT  &trans            &kp SPACE               &kp BACKSPACE          &lt WIN_NUM ENTER  &td_multi_win
             >;
 
             label = "WinCode";
@@ -156,10 +156,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &none
-&kp LEFT_SHIFT    &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none         &none          &none         &sk LC(LEFT_SHIFT)  &none
-                                              &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans        &td_multi_win
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4            &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &none
+&kp LEFT_SHIFT    &none         &none         &none         &none                   &kp HOME        &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
+&kp LEFT_CONTROL  &none         &none         &none         &none                   &kp END         &kp PAGE_DOWN  &none         &none          &none         &sk LC(LEFT_SHIFT)  &none
+                                              &kp LEFT_ALT  &lt WIN_CODE LEFT_SHIFT &kp SPACE       &kp BACKSPACE  &trans        &td_multi_win
             >;
 
             label = "WinNum";
@@ -167,10 +167,10 @@
 
         windows_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6         &kp F7      &kp F8             &kp F9           &kp F10       &kp F11
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F12        &kp C_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &to GAME_DEF  &to MAC_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none         &none
-                                              &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans      &td_multi_win
+&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5          &kp F6         &kp F7      &kp F8             &kp F9           &kp F10       &kp F11
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &kp F12        &kp C_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &to GAME_DEF  &to MAC_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none           &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none         &none
+                                              &kp LEFT_ALT  &trans        &kp SPACE       &kp BACKSPACE  &trans      &td_multi_win
             >;
 
             label = "WinFunc";
@@ -178,10 +178,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y          &kp U              &kp I         &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H          &kp J              &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N          &kp M              &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
-                                &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &lt MAC_NUM ENTER  &kp LEFT_ALT
+&kp TAB           &kp Q  &kp W  &kp E          &kp R                    &kp T        &kp Y          &kp U              &kp I         &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F                    &kp G        &kp H          &kp J              &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V                    &kp B        &kp N          &kp M              &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
+                                &td_multi_mac  &lt MAC_CODE LEFT_SHIFT  &kp SPACE    &kp BACKSPACE  &lt MAC_NUM ENTER  &kp LEFT_ALT
             >;
 
             label = "MacOS";
@@ -192,7 +192,7 @@
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND      &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
 &kp LEFT_SHIFT    &none            &none   &none          &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
 &kp LEFT_CONTROL  &none            &none   &none          &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE     &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
-                                           &td_multi_mac  &trans            &sm LEFT_SHIFT SPACE    &kp BACKSPACE          &lt MAC_NUM ENTER  &kp LEFT_ALT
+                                           &td_multi_mac  &trans            &kp SPACE               &kp BACKSPACE          &lt MAC_NUM ENTER  &kp LEFT_ALT
             >;
 
             label = "MacCode";
@@ -200,10 +200,10 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
-&kp LEFT_SHIFT    &none         &none         &none          &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &sk LC(LEFT_SHIFT)  &sk GLOBE
-                                              &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans        &kp LEFT_ALT
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4             &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
+&kp LEFT_SHIFT    &none         &none         &none          &none                    &kp HOME        &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT           &none
+&kp LEFT_CONTROL  &none         &none         &none          &none                    &kp END         &kp PAGE_DOWN  &none         &none         &none         &sk LC(LEFT_SHIFT)  &sk GLOBE
+                                              &td_multi_mac  &lt MAC_CODE LEFT_SHIFT  &kp SPACE       &kp BACKSPACE  &trans        &kp LEFT_ALT
             >;
 
             label = "MacNum";
@@ -211,10 +211,10 @@
 
         mac_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6         &kp F7      &kp F8             &kp F9           &kp F10  &kp F11
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &kp F12        &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none    &to WIN_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none    &none
-                                              &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans      &kp LEFT_ALT
+&kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5          &kp F6         &kp F7      &kp F8             &kp F9           &kp F10  &kp F11
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4    &kp F12        &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none    &to WIN_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none           &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none    &none
+                                              &td_multi_mac  &trans        &kp SPACE       &kp BACKSPACE  &trans      &kp LEFT_ALT
             >;
 
             label = "MacFunc";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -134,10 +134,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R                   &kp T        &kp Y          &kp U              &kp I          &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F                   &kp G        &kp H          &kp J              &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V                   &kp B        &kp N          &kp M              &kp COMMA      &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &lt WIN_CODE LEFT_SHIFT &kp SPACE    &kp BACKSPACE  &lt WIN_NUM ENTER  &td_multi_win
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y          &kp U              &kp I          &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H          &kp J              &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N          &kp M              &kp COMMA      &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &lt WIN_NUM ENTER  &td_multi_win
             >;
 
             label = "Windows";
@@ -148,7 +148,7 @@
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND      &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
 &kp LEFT_SHIFT    &none            &none   &none         &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
 &kp LEFT_CONTROL  &none            &none   &none         &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE     &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
-                                           &kp LEFT_ALT  &trans            &kp SPACE               &kp BACKSPACE          &lt WIN_NUM ENTER  &td_multi_win
+                                           &kp LEFT_ALT  &trans            &sm LEFT_SHIFT SPACE    &kp BACKSPACE          &lt WIN_NUM ENTER  &td_multi_win
             >;
 
             label = "WinCode";
@@ -156,10 +156,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4            &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &none
-&kp LEFT_SHIFT    &none         &none         &none         &none                   &kp HOME        &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none                   &kp END         &kp PAGE_DOWN  &none         &none          &none         &sk LC(LEFT_SHIFT)  &none
-                                              &kp LEFT_ALT  &lt WIN_CODE LEFT_SHIFT &kp SPACE       &kp BACKSPACE  &trans        &td_multi_win
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &none
+&kp LEFT_SHIFT    &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
+&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none         &none          &none         &sk LC(LEFT_SHIFT)  &none
+                                              &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans        &td_multi_win
             >;
 
             label = "WinNum";
@@ -167,10 +167,10 @@
 
         windows_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5          &kp F6         &kp F7      &kp F8             &kp F9           &kp F10       &kp F11
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &kp F12        &kp C_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &to GAME_DEF  &to MAC_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none           &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none         &none
-                                              &kp LEFT_ALT  &trans        &kp SPACE       &kp BACKSPACE  &trans      &td_multi_win
+&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6         &kp F7      &kp F8             &kp F9           &kp F10       &kp F11
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F12        &kp C_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &to GAME_DEF  &to MAC_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none         &none
+                                              &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans      &td_multi_win
             >;
 
             label = "WinFunc";
@@ -178,10 +178,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E          &kp R                    &kp T        &kp Y          &kp U              &kp I         &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F                    &kp G        &kp H          &kp J              &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V                    &kp B        &kp N          &kp M              &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
-                                &td_multi_mac  &lt MAC_CODE LEFT_SHIFT  &kp SPACE    &kp BACKSPACE  &lt MAC_NUM ENTER  &kp LEFT_ALT
+&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y          &kp U              &kp I         &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H          &kp J              &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N          &kp M              &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
+                                &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &lt MAC_NUM ENTER  &kp LEFT_ALT
             >;
 
             label = "MacOS";
@@ -192,7 +192,7 @@
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND      &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
 &kp LEFT_SHIFT    &none            &none   &none          &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
 &kp LEFT_CONTROL  &none            &none   &none          &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE     &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
-                                           &td_multi_mac  &trans            &kp SPACE               &kp BACKSPACE          &lt MAC_NUM ENTER  &kp LEFT_ALT
+                                           &td_multi_mac  &trans            &sm LEFT_SHIFT SPACE    &kp BACKSPACE          &lt MAC_NUM ENTER  &kp LEFT_ALT
             >;
 
             label = "MacCode";
@@ -200,10 +200,10 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4             &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
-&kp LEFT_SHIFT    &none         &none         &none          &none                    &kp HOME        &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none          &none                    &kp END         &kp PAGE_DOWN  &none         &none         &none         &sk LC(LEFT_SHIFT)  &sk GLOBE
-                                              &td_multi_mac  &lt MAC_CODE LEFT_SHIFT  &kp SPACE       &kp BACKSPACE  &trans        &kp LEFT_ALT
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
+&kp LEFT_SHIFT    &none         &none         &none          &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT           &none
+&kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &sk LC(LEFT_SHIFT)  &sk GLOBE
+                                              &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans        &kp LEFT_ALT
             >;
 
             label = "MacNum";
@@ -211,10 +211,10 @@
 
         mac_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5          &kp F6         &kp F7      &kp F8             &kp F9           &kp F10  &kp F11
-&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4    &kp F12        &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none    &to WIN_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none           &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none    &none
-                                              &td_multi_mac  &trans        &kp SPACE       &kp BACKSPACE  &trans      &kp LEFT_ALT
+&kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6         &kp F7      &kp F8             &kp F9           &kp F10  &kp F11
+&kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &kp F12        &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none    &to WIN_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none    &none
+                                              &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans      &kp LEFT_ALT
             >;
 
             label = "MacFunc";


### PR DESCRIPTION
- 在 `windows_default_layer` 部分新增一個 `kp LEFT_ALT` 的綁定
- 將 `windows_code_layer` 部分的 `kp LEFT_ALT` 綁定更改為包含 `&amp;mo WIN_CODE` 和 `&amp;sm LEFT_SHIFT SPACE`
- 將 `windows_number_layer` 部分的 `kp LEFT_ALT` 綁定更改為包含 `&amp;mo WIN_CODE` 和 `&amp;sm LEFT_SHIFT SPACE`
- 將 `windows_function_layer` 部分的 `kp LEFT_ALT` 綁定更改為包含 `&amp;mo WIN_CODE` 和 `&amp;sm LEFT_SHIFT SPACE`
- 將 `mac_default_layer` 部分的 `kp LEFT_ALT` 綁定更改為包含 `&amp;mo MAC_CODE` 和 `&amp;sm LEFT_SHIFT SPACE`
- 將 `mac_code_layer` 部分的 `kp LEFT_ALT` 綁定更改為包含 `&amp;mo MAC_CODE` 和 `&amp;sm LEFT_SHIFT SPACE`
-

Signed-off-by: DAST-HomePC <jackie@dast.tw>
