### PR TITLE
重構：調整 `sm` 和 `em` 的綁定單元格和快速點擊毫秒值

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -121,7 +121,7 @@
         sm: space_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
-            #binding-cells = <0>;
+            #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
@@ -131,10 +131,10 @@
         em: enter_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "ENTER_MOD";
-            #binding-cells = <0>;
+            #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <200>;
-            quick-tap-ms = <150>;
+            quick-tap-ms = <125>;
             bindings = <&mo>, <&kp>;
         };
     };


### PR DESCRIPTION
- 將 `sm` 和 `em` 的綁定單元格數量從0增加到2
- 將 `em` 的快速點擊毫秒值從150減少到125

Signed-off-by: DAST-HomePC <jackie@dast.tw>
