### PR TITLE
工作: 更新 `config/corne.keymap` 中的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -128,9 +128,9 @@
             bindings = <&kp>, <&kp>;
         };
 
-        em: enter_mod {
+        bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
-            label = "ENTER_MOD";
+            label = "BSPC_MOD";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <200>;
@@ -144,10 +144,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y          &kp U              &kp I          &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H          &kp J              &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N          &kp M              &kp COMMA      &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &em WIN_NUM ENTER  &td_multi_win
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y          &kp U                  &kp I          &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H          &kp J                  &kp K          &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N          &kp M                  &kp COMMA      &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &bm WIN_NUM BACKSPACE  &td_multi_win
             >;
 
             label = "Windows";
@@ -155,10 +155,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND      &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
-&kp LEFT_SHIFT    &none            &none   &none         &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none         &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE     &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
-                                           &kp LEFT_ALT  &trans            &sm LEFT_SHIFT SPACE    &kp BACKSPACE          &em WIN_NUM ENTER  &td_multi_win
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH      &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND          &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
+&kp LEFT_SHIFT    &none            &none   &none         &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET      &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none         &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE         &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
+                                           &kp LEFT_ALT  &trans            &sm LEFT_SHIFT SPACE    &kp ENTER              &bm WIN_NUM BACKSPACE  &td_multi_win
             >;
 
             label = "WinCode";
@@ -169,7 +169,7 @@
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8   &kp NUMBER_9  &kp NUMBER_0        &none
 &kp LEFT_SHIFT    &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT           &none
 &kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none         &none          &none         &sk LC(LEFT_SHIFT)  &none
-                                              &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans        &td_multi_win
+                                              &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &td_multi_win
             >;
 
             label = "WinNum";
@@ -180,7 +180,7 @@
 &kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6         &kp F7      &kp F8             &kp F9           &kp F10       &kp F11
 &kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F12        &kp C_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &to GAME_DEF  &to MAC_DEF
 &kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none         &none
-                                              &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans      &td_multi_win
+                                              &kp LEFT_ALT  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER      &trans      &td_multi_win
             >;
 
             label = "WinFunc";
@@ -188,10 +188,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y          &kp U              &kp I         &kp O    &kp P          &kp MINUS
-&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H          &kp J              &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N          &kp M              &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
-                                &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &em MAC_NUM ENTER  &kp LEFT_ALT
+&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y          &kp U                  &kp I         &kp O    &kp P          &kp MINUS
+&kp LEFT_SHIFT    &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H          &kp J                  &kp K         &kp L    &kp SEMICOLON  &kp APOSTROPHE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N          &kp M                  &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
+                                &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &bm MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
             label = "MacOS";
@@ -199,10 +199,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND      &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
-&kp LEFT_SHIFT    &none            &none   &none          &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE     &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
-                                           &td_multi_mac  &trans            &sm LEFT_SHIFT SPACE    &kp BACKSPACE          &em MAC_NUM ENTER  &kp LEFT_ALT
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND          &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
+&kp LEFT_SHIFT    &none            &none   &none          &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET      &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
+&kp LEFT_CONTROL  &none            &none   &none          &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE         &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
+                                           &td_multi_mac  &trans            &sm LEFT_SHIFT SPACE    &kp ENTER              &bm MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 
             label = "MacCode";
@@ -213,7 +213,7 @@
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3   &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &kp BACKSPACE
 &kp LEFT_SHIFT    &none         &none         &none          &none         &kp HOME                &kp PAGE_UP    &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT           &none
 &kp LEFT_CONTROL  &none         &none         &none          &none         &kp END                 &kp PAGE_DOWN  &none         &none         &none         &sk LC(LEFT_SHIFT)  &sk GLOBE
-                                              &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans        &kp LEFT_ALT
+                                              &td_multi_mac  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans        &kp LEFT_ALT
             >;
 
             label = "MacNum";
@@ -224,7 +224,7 @@
 &kp TAB           &kp F1        &kp F2        &kp F3         &kp F4        &kp F5                  &kp F6         &kp F7      &kp F8             &kp F9           &kp F10  &kp F11
 &kp LEFT_SHIFT    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2   &bt BT_SEL 3  &bt BT_SEL 4            &kp F12        &kp K_MUTE  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none    &to WIN_DEF
 &kp LEFT_CONTROL  &bt BT_CLR    &none         &none          &none         &none                   &kp C_PP       &kp C_NEXT  &kp C_PREV         &none            &none    &none
-                                              &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp BACKSPACE  &trans      &kp LEFT_ALT
+                                              &td_multi_mac  &trans        &sm LEFT_SHIFT SPACE    &kp ENTER  &trans      &kp LEFT_ALT
             >;
 
             label = "MacFunc";


### PR DESCRIPTION
- 在文件 `config/corne.keymap` 中將 `em: enter_mod` 的標籤更改為 `bm: bspc_mod`
- 更新文件 `config/corne.keymap` 中 `windows_default_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `windows_code_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `windows_number_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `windows_function_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `mac_default_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `mac_code_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `mac_number_layer` 區塊的綁定
- 更新文件 `config/corne.keymap` 中 `mac_function_layer` 區塊的綁定

Signed-off-by: DAST-HomePC <jackie@dast.tw>
