### PR TITLE
重構：重構 `windows_function` 和 `mac_function` 中的條件層賦值

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -257,13 +257,13 @@
         compatible = "zmk,conditional-layers";
 
         windows_function {
-            if-layers = <1 2>;
-            then-layer = <3>;
+            if-layers = <WIN_CODE WIN_NUM>;
+            then-layer = <WIN_FUNC>;
         };
 
         mac_function {
-            if-layers = <5 6>;
-            then-layer = <7>;
+            if-layers = <MAC_CODE MAC_NUM>;
+            then-layer = <MAC_FUNC>;
         };
     };
 };


### PR DESCRIPTION
- 修改 `windows_function` 的條件層，使用 `WIN_CODE` 和 `WIN_NUM` 層代替 `1` 和 `2`
- 修改 `mac_function` 的條件層，使用 `MAC_CODE` 和 `MAC_NUM` 層代替 `5` 和 `6`

Signed-off-by: DAST-HomePC <jackie@dast.tw>
