### PR TITLE
事務：更新 MacCode 的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -201,7 +201,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH       &kp DOLLAR        &kp PERCENT             &kp CARET              &kp AMPERSAND          &kp STAR           &kp PLUS   &kp NON_US_BACKSLASH  &kp GRAVE
 &kp LEFT_SHIFT    &none            &none   &none          &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS    &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET      &kp QUESTION       &kp MINUS  &kp COLON             &kp PIPE
-&kp LEFT_CONTROL  &none            &none   &none          &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE         &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp TILDE
+&kp LEFT_CONTROL  &none            &none   &none          &none             &kp LEFT_BRACE          &kp RIGHT_BRACE        &kp APOSTROPHE         &kp DOUBLE_QUOTES  &kp EQUAL  &sk LC(LEFT_SHIFT)    &kp GLOBE
                                            &td_multi_mac  &trans            &sm LEFT_SHIFT SPACE    &kp ENTER              &bm MAC_NUM BACKSPACE  &kp LEFT_ALT
             >;
 


### PR DESCRIPTION
- 修改 `corne.keymap` 檔案
- 將 `kp TAB` 的綁定改為 `kp EXCLAMATION`、`kp AT`、`kp HASH`、`kp DOLLAR`、`kp PERCENT`、`kp CARET`、`kp AMPERSAND`、`kp STAR`、`kp PLUS`、`kp NON_US_BACKSLASH`、`kp GRAVE`
- 將 `kp LEFT_SHIFT` 的綁定改為無
- 將 `kp LEFT_BRACKET` 的綁定改為 `kp LEFT_PARENTHESIS`、`kp RIGHT_PARENTHESIS`、`kp RIGHT_BRACKET`、`kp QUESTION`、`kp MINUS`、`kp COLON`、`kp PIPE`
- 將 `kp LEFT_CONTROL` 的綁定改為無、`kp LEFT_BRACE`、`kp RIGHT_BRACE`、`kp APOSTROPHE`、`kp DOUBLE_QUOTES`、`kp EQUAL`、`sk LC(LEFT_SHIFT)`、`kp TILDE`
- 將 `kp LEFT_CONTROL` 的綁定改為無、`kp LEFT_BRACE`、`kp RIGHT_BRACE`、`kp APOST

Signed-off-by: DAST-HomePC <jackie@dast.tw>
