### PR TITLE
樣式：將“td_multi_mac”的綁定更新為使用“LEFT_GUI”而不是“LEFT_SHIFT”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/view.jpg)   
    
-KEY TAB + KEY Q = ESC   
-KEY P + KEY - = DEL   
-Layer win_code + Layer win_num = Layer win_func   
-Layer mac_code + Layer mac_num = Layer mac_func   
-To 4 = Change Layer into MAC_DEF   
-To 8 = Change Layer into GAME_DEF   
+按鍵 TAB + 按鍵 Q 同時按 = ESC   
+按鍵 P + 按鍵 - 同時按 = DEL   
+按鍵 win_code + 按鍵 win_num 同時按 = Layer windown_function_layer   
+按鍵 mac_code + 按鍵 mac_num 同時按 = Layer mac_function_layer   
+To 4 = 切換至 mac_default_layer   
+To 8 = 切換至 game_default_layer   
    
 ## td_multi_win   
-The key first hit = WIN_GUI   
-The key secend hit = Screenshot   
-The key third hit = Open Windows Terminal   
+第一下或按住 = WIN_GUI   
+快速點兩下 = 打開截圖   
+快速點三下 = 打開 Windows 終端機   
    
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/win_def.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/win_code.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/win_num.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/win_func.png)
    
-To 0 = Change Layer into WIN_DEF   
+To 0 = 切換至 windows_default_layer   
    
 ### td_multi_mac   
-The key first hit = Shift   
-The key secend hit = Screenshot   
-The key third hit = Spotlight   
+第一下或按住 = Shift   
+快速點兩下 = 打開截圖   
+快速點三下 = Spotlight   
    
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/mac_def.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/mac_code.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/mac_num.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/mac_func.png)
    
-To 0 = Change Layer into WIN_DEF   
+To 0 = 切換至 windows_default_layer   
    
-Game mode setting for CS2   
+Game mode 設定給 CS2 專用   
    
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/game_def.png)
 ![image](https://github.com/cloverdefa/corne-wireless-view-zmk-config/blob/main/IMG/game_opt.png)

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -79,11 +79,11 @@
             #binding-cells = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LGUI &kp LEFT_SHIFT>,
+                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_ALT>,
                 <&macro_tap>,
                 <&kp NUMBER_4>,
                 <&macro_release>,
-                <&kp LGUI &kp LEFT_SHIFT>;
+                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_ALT>;
         };
     };
 
@@ -168,10 +168,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7            &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &none
-&td_multi_win     &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT                &kp DOWN      &kp UP        &kp RIGHT           &none
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none                   &none         &none         &sk LC(LEFT_SHIFT)  &none
-                                              &trans        &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &bm WIN_NUM BACKSPACE   &trans
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7           &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0        &none
+&td_multi_win     &none         &none         &none         &none         &kp HOME                &kp PAGE_UP    &kp LEFT               &kp DOWN      &kp UP        &kp RIGHT           &none
+&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none                  &none         &none         &sk LC(LEFT_SHIFT)  &none
+                                              &trans        &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &bm WIN_NUM BACKSPACE  &trans
             >;
 
             label = "WinNum";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -117,7 +117,7 @@
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LEFT_SHIFT>, <&screenshot_mac>, <&spotlight>;
+            bindings = <&kp LEFT_GUI>, <&screenshot_mac>, <&spotlight>;
         };
 
         sm: space_mod {


### PR DESCRIPTION
- 將“td_multi_mac”的綁定從“&amp;lt;&amp;amp;kp LEFT_SHIFT&amp;gt;”更改為“&amp;lt;&amp;amp;kp LEFT_GUI&amp;gt;”

Signed-off-by: Macbook <jackie@dast.tw>
