### PR TITLE
工作: 將 "spotlight" 鍵盤映射的標籤更改為 "SPOTLIGHT"

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -66,7 +66,7 @@
         };
 
         spotlight: spotlight {
-            label = "spotlight";
+            label = "SPOTLIGHT";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =


### PR DESCRIPTION
- 將 "spotlight" 鍵盤映射的標籤從 "spotlight" 更改為 "SPOTLIGHT"

Signed-off-by: Macbook <jackie@dast.tw>
