### PR TITLE
工作: 為不同的作業系統和遊戲選項添加按鍵映射標籤

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -163,113 +163,103 @@
         compatible = "zmk,keymap";
 
         windows_default_layer {
+            label = "Windows";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
 &td_multi_win     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "Windows";
         };
 
         windows_code_layer {
+            label = "WinCode";
             bindings = <
 &kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                                &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinCode";
         };
 
         windows_number_layer {
+            label = "WinNum";
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                                      &trans          &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinNum";
         };
 
         windows_function_layer {
+            label = "WinFunc";
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
 &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to MAC_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinFunc";
         };
 
         mac_default_layer {
+            label = "MacOS";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
 &td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacOS";
         };
 
         mac_code_layer {
+            label = "MacCode";
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
 &kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                            &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacCode";
         };
 
         mac_number_layer {
+            label = "MacNum";
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                               &trans          &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacNum";
         };
 
         mac_function_layer {
+            label = "MacFunc";
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
 &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to WIN_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacFunc";
         };
 
         game_default_layer {
+            label = "Game";
             bindings = <
 &kp TAB           &none         &kp Q  &kp W  &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
 &kp LEFT_SHIFT    &kp NUMBER_2  &kp A  &kp S  &kp D         &none           &none   &none   &none   &none   &none  &none
 &kp LEFT_CONTROL  &kp NUMBER_1  &none  &none  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                        &sk Z  &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
             >;
-
-            label = "Game";
         };
 
         game_option_layer {
+            label = "Option";
             bindings = <
 &kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
 &trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
-
-            label = "Option";
         };
     };
 


### PR DESCRIPTION
- 將標籤 "Windows" 添加到 `windows_default_layer` 鍵映射
- 將標籤 "WinCode" 添加到 `windows_code_layer` 鍵映射
- 將標籤 "WinNum" 添加到 `windows_number_layer` 鍵映射
- 將標籤 "WinFunc" 添加到 `windows_function_layer` 鍵映射
- 將標籤 "MacOS" 添加到 `mac_default_layer` 鍵映射
- 將標籤 "MacCode" 添加到 `mac_code_layer` 鍵映射
- 將標籤 "MacNum" 添加到 `mac_number_layer` 鍵映射
- 將標籤 "MacFunc" 添加到 `mac_function_layer` 鍵映射
- 將標籤 "Game" 添加到 `game_default_layer` 鍵映射
- 將標籤 "Option" 添加到 `game_option_layer`

Signed-off-by: Macbook <jackie@dast.tw>
