### PR TITLE
release

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Alexey Potapov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -131,7 +131,7 @@
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
             #binding-cells = <2>;
-            flavor = "balanced";
+            flavor = "tap-preferred";
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&kp>, <&kp>;
@@ -145,6 +145,17 @@
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&mo>, <&kp>;
+        };
+
+        bm: bspc_mod {
+            compatible = "zmk,behavior-hold-tap";
+            label = "BSPC_MOD";
+            bindings = <&mo>, <&kp>;
+
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
+            flavor = "hold-preferred";
         };
     };
 
@@ -166,7 +177,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                                &trans    &trans          &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE      &kp LC(LEFT_SHIFT)
             >;
 
@@ -177,7 +188,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &none
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                                      &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER    &kp BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
 
@@ -188,7 +199,7 @@
             bindings = <
 &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none        &none          &none               &none  &none         &none
 &kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none        &none          &none               &none  &to GAME_DEF  &to MAC_DEF
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none        &none          &none               &none  &none         &none
+&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none        &none          &none               &none  &none         &kp LEFT_ALT
                                           &trans        &trans        &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -66,7 +66,7 @@
         };
 
         spotlight: spotlight {
-            label = "SPOTLIGHT";
+            label = "spotlight";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
@@ -137,6 +137,16 @@
             bindings = <&kp>, <&kp>;
         };
 
+        em: enter_mod {
+            compatible = "zmk,behavior-hold-tap";
+            label = "ENTER_MOD";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
+            bindings = <&mo>, <&kp>;
+        };
+
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
@@ -154,23 +164,24 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_win     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 2 BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
-            lbel = "Windows";
+            label = "Windows";
         };
 
         windows_code_layer {
-            label = "WinCode";
             bindings = <
-&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 2 BACKSPACE    &kp LC(LEFT_SHIFT)
             >;
+
+            label = "WinCode";
         };
 
         windows_number_layer {
@@ -197,10 +208,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 6 BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacOS";
@@ -208,10 +219,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 6 BACKSPACE    &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacCode";
@@ -222,7 +233,7 @@
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
-                                              &trans          &mo MAC_NUM       &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
+                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacNum";
@@ -231,7 +242,7 @@
         mac_function_layer {
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
-&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &none         &to WIN_DEF
+&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to 8         &to WIN_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
@@ -253,7 +264,7 @@
         game_option_layer {
             bindings = <
 &kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
-&trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
+&trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to 0
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -163,13 +163,14 @@
         compatible = "zmk,keymap";
 
         windows_default_layer {
-            lbel = "Windows";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
 &td_multi_win     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
+
+            lbel = "Windows";
         };
 
         windows_code_layer {
@@ -183,83 +184,91 @@
         };
 
         windows_number_layer {
-            label = "WinNum";
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                                      &trans          &mo 1             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
+            
+            label = "WinNum";
         };
 
         windows_function_layer {
-            label = "WinFunc";
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
 &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to MAC_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
+            
+            label = "WinFunc";
         };
 
         mac_default_layer {
-            label = "MacOS";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
 &td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
+            
+            label = "MacOS";
         };
 
         mac_code_layer {
-            label = "MacCode";
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
 &kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                            &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
+            
+            label = "MacCode";
         };
 
         mac_number_layer {
-            label = "MacNum";
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                               &trans          &mo MAC_NUM       &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
+            
+            label = "MacNum";
         };
 
         mac_function_layer {
-            label = "MacFunc";
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
 &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to WIN_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
+            
+            label = "MacFunc";
         };
 
         game_default_layer {
-            label = "Game";
             bindings = <
 &kp TAB           &none         &kp Q  &kp W  &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
 &kp LEFT_SHIFT    &kp NUMBER_2  &kp A  &kp S  &kp D         &none           &none   &none   &none   &none   &none  &none
 &kp LEFT_CONTROL  &kp NUMBER_1  &none  &none  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                        &sk Z  &mo 9         &kp SPACE       &kp M   &none   &none
             >;
+            
+            label = "Game";
         };
 
         game_option_layer {
-            label = "Option";
             bindings = <
 &kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
 &trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
+            
+            label = "Option";
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -116,7 +116,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LGUI>, <&screenshot_win>, <&terminal_win>;
+            bindings = <&kp LEFT_GUI>, <&screenshot_win>, <&terminal_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {
@@ -231,7 +231,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7            &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW          &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none                   &none               &none            &kp PAGE_DOWN  &sk LC(LEFT_SHIFT)
+&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none                   &none               &none            &kp PAGE_DOWN  &none
                                               &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -35,6 +35,7 @@
             bindings =
                 <&macro_press>,
                 <&kp LGUI>,
+                <&macro_wait_time 100>,
                 <&macro_tap>,
                 <&kp R>,
                 <&macro_release>,
@@ -45,6 +46,7 @@
                 <&macro_wait_time 100>,
                 <&macro_tap>,
                 <&kp W &kp T>,
+                <&macro_wait_time 100>,
                 <&macro_tap>,
                 <&kp ENTER>;
         };
@@ -174,7 +176,7 @@
         windows_number_layer {
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9     &kp NUMBER_0  &kp C_VOLUME_UP
-&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &none           &kp UP_ARROW    &none            &none         &kp C_VOLUME_DOWN
+&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp UP_ARROW    &kp RIGHT_ARROW  &none         &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &none         &sk LC(LEFT_SHIFT)
                                                      &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER    &kp BACKSPACE   &trans
             >;
@@ -218,7 +220,7 @@
         mac_number_layer {
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9     &kp NUMBER_0  &kp C_VOLUME_UP
-&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &none           &kp UP_ARROW    &none            &none         &kp C_VOLUME_DOWN
+&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp UP_ARROW    &kp RIGHT_ARROW  &none         &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &none         &sk LC(LEFT_SHIFT)
                                               &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER    &kp BACKSPACE   &trans
             >;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -66,7 +66,7 @@
         };
 
         spotlight: spotlight {
-            label = "spotlight";
+            label = "SPOTLIGHT";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
@@ -163,113 +163,103 @@
         compatible = "zmk,keymap";
 
         windows_default_layer {
+            lbel = "Windows";
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 2 BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_win     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "Windows";
         };
 
         windows_code_layer {
-            bindings = <
-&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 2 BACKSPACE    &kp LC(LEFT_SHIFT)
-            >;
-
             label = "WinCode";
+            bindings = <
+&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+            >;
         };
 
         windows_number_layer {
+            label = "WinNum";
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                                      &trans          &mo 1             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinNum";
         };
 
         windows_function_layer {
-            bindings = <
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none   &none   &none               &none  &none         &none
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none   &none   &none               &none  &to GAME_DEF  &to MAC_DEF
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none   &none   &none               &none  &none         &kp LEFT_ALT
-                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &trans  &trans  &kp LC(LEFT_SHIFT)
-            >;
-
             label = "WinFunc";
+            bindings = <
+&kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
+&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to MAC_DEF
+&none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
+                        &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
+            >;
         };
 
         mac_default_layer {
-            bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 6 BACKSPACE  &kp LC(LEFT_SHIFT)
-            >;
-
             label = "MacOS";
+            bindings = <
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+            >;
         };
 
         mac_code_layer {
-            bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 6 BACKSPACE    &kp LC(LEFT_SHIFT)
-            >;
-
             label = "MacCode";
+            bindings = <
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+            >;
         };
 
         mac_number_layer {
+            label = "MacNum";
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
+                                              &trans          &mo MAC_NUM       &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacNum";
         };
 
         mac_function_layer {
-            bindings = <
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none   &none   &none               &none  &none  &none
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none   &none   &none               &none  &to 8  &to WIN_DEF
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none   &none   &none               &none  &none  &kp LEFT_ALT
-                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &trans  &trans  &kp LC(LEFT_SHIFT)
-            >;
-
             label = "MacFunc";
+            bindings = <
+&kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
+&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to WIN_DEF
+&none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
+                        &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
+            >;
         };
 
         game_default_layer {
+            label = "Game";
             bindings = <
 &kp TAB           &none         &kp Q  &kp W  &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
 &kp LEFT_SHIFT    &kp NUMBER_2  &kp A  &kp S  &kp D         &none           &none   &none   &none   &none   &none  &none
 &kp LEFT_CONTROL  &kp NUMBER_1  &none  &none  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                        &sk Z  &mo 9         &kp SPACE       &kp M   &none   &none
             >;
-
-            label = "Game";
         };
 
         game_option_layer {
+            label = "Option";
             bindings = <
 &kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
-&trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to 0
+&trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
-
-            label = "Option";
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -131,24 +131,20 @@
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
             #binding-cells = <2>;
-            flavor = "tap-preferred";
+            flavor = "balanced";
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&kp>, <&kp>;
-
-            hold-trigger-key-positions = <38>;
         };
 
         em: enter_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "ENTER_MOD";
             #binding-cells = <2>;
-            flavor = "hold-preferred";
+            flavor = "balanced";
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&mo>, <&kp>;
-
-            hold-trigger-key-positions = <39>;
         };
 
         bm: bspc_mod {
@@ -159,8 +155,7 @@
             #binding-cells = <2>;
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
-            flavor = "hold-preferred";
-            hold-trigger-key-positions = <40>;
+            flavor = "balanced";
         };
     };
 
@@ -169,10 +164,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U          &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J          &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M          &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 2 BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "Windows";
@@ -180,10 +175,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE      &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 2 BACKSPACE    &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinCode";
@@ -194,7 +189,7 @@
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
-                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER    &kp BACKSPACE   &kp LC(LEFT_SHIFT)
+                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinNum";
@@ -202,10 +197,10 @@
 
         windows_function_layer {
             bindings = <
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none        &none          &none               &none  &none         &none
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none        &none          &none               &none  &to GAME_DEF  &to MAC_DEF
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none        &none          &none               &none  &none         &kp LEFT_ALT
-                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
+&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none   &none   &none               &none  &none         &none
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none   &none   &none               &none  &to GAME_DEF  &to MAC_DEF
+&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none   &none   &none               &none  &none         &kp LEFT_ALT
+                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &trans  &trans  &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinFunc";
@@ -213,10 +208,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U  &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &em 6 ENTER  &none  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 6 BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacOS";
@@ -224,10 +219,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE      &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 6 BACKSPACE    &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacCode";
@@ -238,7 +233,7 @@
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER    &kp BACKSPACE   &kp LC(LEFT_SHIFT)
+                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacNum";
@@ -246,10 +241,10 @@
 
         mac_function_layer {
             bindings = <
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none        &none          &none               &none  &none  &none
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none        &none          &none               &none  &to 8  &to WIN_DEF
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none        &none          &none               &none  &none  &kp LEFT_ALT
-                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
+&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none   &none   &none               &none  &none  &none
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none   &none   &none               &none  &to 8  &to WIN_DEF
+&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none   &none   &none               &none  &none  &kp LEFT_ALT
+                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &trans  &trans  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacFunc";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -137,16 +137,6 @@
             bindings = <&kp>, <&kp>;
         };
 
-        em: enter_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "ENTER_MOD";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
-            bindings = <&mo>, <&kp>;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
@@ -190,7 +180,7 @@
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                                      &trans          &mo 1             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-            
+
             label = "WinNum";
         };
 
@@ -201,7 +191,7 @@
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
-            
+
             label = "WinFunc";
         };
 
@@ -212,7 +202,7 @@
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-            
+
             label = "MacOS";
         };
 
@@ -223,7 +213,7 @@
 &kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                            &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-            
+
             label = "MacCode";
         };
 
@@ -234,18 +224,18 @@
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                               &trans          &mo MAC_NUM       &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-            
+
             label = "MacNum";
         };
 
         mac_function_layer {
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
-&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to WIN_DEF
+&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &none         &to WIN_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
-            
+
             label = "MacFunc";
         };
 
@@ -256,7 +246,7 @@
 &kp LEFT_CONTROL  &kp NUMBER_1  &none  &none  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                        &sk Z  &mo 9         &kp SPACE       &kp M   &none   &none
             >;
-            
+
             label = "Game";
         };
 
@@ -267,7 +257,7 @@
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
-            
+
             label = "Option";
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -115,7 +115,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
-            tapping-term-ms = <200>;
+            tapping-term-ms = <300>;
             bindings = <&kp LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
@@ -123,7 +123,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
-            tapping-term-ms = <200>;
+            tapping-term-ms = <300>;
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -66,7 +66,7 @@
         };
 
         spotlight: spotlight {
-            label = "spotlight";
+            label = "SPOTLIGHT";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
@@ -164,10 +164,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 2 BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_win     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "Windows";
@@ -175,10 +175,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 2 BACKSPACE    &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinCode";
@@ -189,7 +189,7 @@
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
-                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
+                                                     &trans          &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinNum";
@@ -208,10 +208,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y      &kp U            &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H      &kp J            &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N      &kp M            &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm 6 BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacOS";
@@ -219,10 +219,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
-                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm 6 BACKSPACE    &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacCode";
@@ -233,7 +233,7 @@
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
+                                              &trans          &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacNum";
@@ -242,7 +242,7 @@
         mac_function_layer {
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
-&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to 8         &to WIN_DEF
+&kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to WIN_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
@@ -255,7 +255,7 @@
 &kp TAB           &none         &kp Q  &kp W  &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
 &kp LEFT_SHIFT    &kp NUMBER_2  &kp A  &kp S  &kp D         &none           &none   &none   &none   &none   &none  &none
 &kp LEFT_CONTROL  &kp NUMBER_1  &none  &none  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
-                                       &sk Z  &mo 9         &kp SPACE       &kp M   &none   &none
+                                       &sk Z  &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
             >;
 
             label = "Game";
@@ -264,7 +264,7 @@
         game_option_layer {
             bindings = <
 &kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
-&trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to 0
+&trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -175,10 +175,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
-&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none               &none            &kp PAGE_DOWN  &none
-                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER     &kp BACKSPACE   &kp LC(LEFT_SHIFT)
+&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
+&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &none
+                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER    &kp BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinNum";
@@ -186,10 +186,10 @@
 
         windows_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7         &kp F8              &kp F9  &kp F10       &none
-&td_multi_win     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12        &none               &none   &to GAME_DEF  &to MAC_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none          &none               &none   &none         &none
-                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
+&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none        &none          &none               &none  &none         &none
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none        &none          &none               &none  &to GAME_DEF  &to MAC_DEF
+&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none        &none          &none               &none  &none         &none
+                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinFunc";
@@ -219,10 +219,10 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
-&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none               &none            &kp PAGE_DOWN  &kp LEFT_ALT
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &kp BACKSPACE   &kp LC(LEFT_SHIFT)
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
+&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
+                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER    &kp BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacNum";
@@ -230,10 +230,10 @@
 
         mac_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7         &kp F8              &kp F9  &kp F10  &none
-&td_multi_mac     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12        &none               &none   &to 8    &to WIN_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none          &none               &none   &none    &kp LEFT_ALT
-                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
+&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR              &none        &none          &none               &none  &none  &none
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                  &none        &none          &none               &none  &to 8  &to WIN_DEF
+&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12                 &none        &none          &none               &none  &none  &kp LEFT_ALT
+                                          &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacFunc";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -163,113 +163,103 @@
         compatible = "zmk,keymap";
 
         windows_default_layer {
+            label = "Windows";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
 &td_multi_win     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "Windows";
         };
 
         windows_code_layer {
+            label = "WinCode";
             bindings = <
 &kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                                &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinCode";
         };
 
         windows_number_layer {
+            label = "WinNum";
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                                      &trans          &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinNum";
         };
 
         windows_function_layer {
+            label = "WinFunc";
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
 &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to MAC_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
-
-            label = "WinFunc";
         };
 
         mac_default_layer {
+            label = "MacOS";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp MINUS
 &td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
 &kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacOS";
         };
 
         mac_code_layer {
+            label = "MacCode";
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
 &kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
                                            &trans    &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacCode";
         };
 
         mac_number_layer {
+            label = "MacNum";
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
 &td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
 &kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none               &none         &none            &kp LEFT_ALT
                                               &trans          &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans          &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacNum";
         };
 
         mac_function_layer {
+            label = "MacFunc";
             bindings = <
 &kp F1  &kp F2  &kp F3  &kp F4   &kp F5   &kp F6                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR
 &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12                 &none         &none         &none               &none         &to GAME_DEF  &to WIN_DEF
 &none   &none   &none   &none    &none    &none                   &none         &none         &none               &none         &none         &kp LEFT_ALT
                         &trans   &trans   &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
-
-            label = "MacFunc";
         };
 
         game_default_layer {
+            label = "Game";
             bindings = <
 &kp TAB           &none         &kp Q  &kp W  &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
 &kp LEFT_SHIFT    &kp NUMBER_2  &kp A  &kp S  &kp D         &none           &none   &none   &none   &none   &none  &none
 &kp LEFT_CONTROL  &kp NUMBER_1  &none  &none  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                        &sk Z  &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
             >;
-
-            label = "Game";
         };
 
         game_option_layer {
+            label = "Option";
             bindings = <
 &kp B   &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
 &trans  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
 &kp G   &none         &none         &none         &none         &none           &none  &none  &none  &none  &none  &none
                                     &none         &trans        &trans          &none  &none  &none
             >;
-
-            label = "Option";
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -116,7 +116,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LEFT_GUI>, <&screenshot_win>, <&terminal_win>;
+            bindings = <&kp LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {
@@ -124,7 +124,7 @@
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LEFT_GUI>, <&screenshot_mac>, <&spotlight>;
+            bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
         sm: space_mod {
@@ -145,16 +145,6 @@
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&mo>, <&kp>;
-        };
-
-        bm: bspc_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "BSPC_MOD";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
-            bindings = <&kp>, <&kp>;
         };
     };
 
@@ -207,10 +197,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U                   &kp I               &kp O    &kp P          &kp MINUS
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J                   &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U  &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J  &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M  &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &em 6 ENTER  &none  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacOS";
@@ -218,10 +208,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LEFT_ALT
+                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE      &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacCode";
@@ -229,10 +219,10 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7            &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
-&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW          &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none                   &none               &none            &kp PAGE_DOWN  &none
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
+&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none               &none            &kp PAGE_DOWN  &kp LEFT_ALT
+                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &kp BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacNum";
@@ -240,10 +230,10 @@
 
         mac_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7                  &kp F8              &kp F9  &kp F10  &none
-&td_multi_mac     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12                 &none               &none   &to 8    &to WIN_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none                   &none               &none   &none    &none
-                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7         &kp F8              &kp F9  &kp F10  &none
+&td_multi_mac     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12        &none               &none   &to 8    &to WIN_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none          &none               &none   &none    &kp LEFT_ALT
+                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacFunc";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -175,10 +175,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
-&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none           &none         &none            &sk LC(LEFT_SHIFT)
-                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER    &kp BACKSPACE   &trans
+&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8  &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
+&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none         &none            &kp PAGE_DOWN  &sk LC(LEFT_SHIFT)
+                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER     &kp BACKSPACE   &trans
             >;
 
             label = "WinNum";
@@ -219,10 +219,10 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
-&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none           &none         &none            &sk LC(LEFT_SHIFT)
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER    &kp BACKSPACE   &trans
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8  &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
+&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none         &none            &kp PAGE_DOWN  &sk LC(LEFT_SHIFT)
+                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &kp BACKSPACE   &trans
             >;
 
             label = "MacNum";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -35,18 +35,18 @@
             bindings =
                 <&macro_press>,
                 <&kp LGUI>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp R>,
                 <&macro_release>,
                 <&kp LGUI>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp BACKSPACE>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp W &kp T>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp ENTER>;
         };
@@ -58,7 +58,7 @@
             bindings =
                 <&macro_press>,
                 <&kp LGUI &kp LEFT_SHIFT>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp S>,
                 <&macro_release>,
@@ -72,7 +72,7 @@
             bindings =
                 <&macro_press>,
                 <&kp LGUI>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
@@ -86,7 +86,7 @@
             bindings =
                 <&macro_press>,
                 <&kp LGUI &kp LEFT_SHIFT &kp LEFT_ALT>,
-                <&macro_wait_time 100>,
+                <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp NUMBER_4>,
                 <&macro_release>,
@@ -175,9 +175,9 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9     &kp NUMBER_0  &kp C_VOLUME_UP
-&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp UP_ARROW    &kp RIGHT_ARROW  &none         &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &none         &sk LC(LEFT_SHIFT)
+&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
+&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none           &none         &none            &sk LC(LEFT_SHIFT)
                                                      &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER    &kp BACKSPACE   &trans
             >;
 
@@ -219,9 +219,9 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9     &kp NUMBER_0  &kp C_VOLUME_UP
-&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp UP_ARROW    &kp RIGHT_ARROW  &none         &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &none         &sk LC(LEFT_SHIFT)
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp C_VOLUME_UP
+&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &none           &none           &none         &none            &sk LC(LEFT_SHIFT)
                                               &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER    &kp BACKSPACE   &trans
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -85,12 +85,12 @@
             #binding-cells = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_ALT>,
+                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_CONTROL>,
                 <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp NUMBER_4>,
                 <&macro_release>,
-                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_ALT>;
+                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_CONTROL>;
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -135,6 +135,8 @@
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&kp>, <&kp>;
+
+            hold-trigger-key-positions = <38>;
         };
 
         em: enter_mod {
@@ -145,6 +147,8 @@
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&mo>, <&kp>;
+
+            hold-trigger-key-positions = <39>;
         };
 
         bm: bspc_mod {
@@ -156,6 +160,7 @@
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             flavor = "hold-preferred";
+            hold-trigger-key-positions = <40>;
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -220,7 +220,7 @@
             bindings = <
 &kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &sk LC(LEFT_SHIFT)
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
                                            &trans    &trans          &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -141,10 +141,20 @@
             compatible = "zmk,behavior-hold-tap";
             label = "ENTER_MOD";
             #binding-cells = <2>;
-            flavor = "balanced";
+            flavor = "hold-preferred";
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             bindings = <&mo>, <&kp>;
+        };
+
+        bm: bspc_mod {
+            compatible = "zmk,behavior-hold-tap";
+            label = "BSPC_MOD";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
+            bindings = <&kp>, <&kp>;
         };
     };
 
@@ -153,10 +163,10 @@
 
         windows_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U          &kp I      &kp O    &kp P          &kp MINUS
-&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J          &kp K      &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M          &kp COMMA  &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &none
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U          &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_win     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J          &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M          &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_ALT  &mo 1  &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "Windows";
@@ -164,10 +174,10 @@
 
         windows_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &sk LC(LEFT_SHIFT)
-                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE      &trans
+&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_win     &none                &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                               &trans    &trans          &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE      &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinCode";
@@ -175,10 +185,10 @@
 
         windows_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8  &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
-&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none         &none            &kp PAGE_DOWN  &sk LC(LEFT_SHIFT)
-                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER     &kp BACKSPACE   &trans
+&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
+&td_multi_win     &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none               &none            &kp PAGE_DOWN  &none
+                                                     &trans          &mo 1             &sm LEFT_SHIFT SPACE    &em 2 ENTER     &kp BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinNum";
@@ -186,10 +196,10 @@
 
         windows_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7         &kp F8  &kp F9  &kp F10       &none
-&td_multi_win     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12        &none   &none   &to GAME_DEF  &to MAC_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none          &none   &none   &none         &none
-                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &trans
+&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7         &kp F8              &kp F9  &kp F10       &none
+&td_multi_win     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12        &none               &none   &to GAME_DEF  &to MAC_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none          &none               &none   &none         &none
+                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 2 ENTER  &kp BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "WinFunc";
@@ -197,10 +207,10 @@
 
         mac_default_layer {
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U          &kp I         &kp O    &kp P          &kp MINUS
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J          &kp K         &kp L    &kp SEMICOLON  &kp GRAVE
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M          &kp COMMA     &kp DOT  &kp SLASH      &kp TILDE
-                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE  &kp LEFT_ALT
+&kp TAB           &kp Q  &kp W  &kp E         &kp R  &kp T                   &kp Y        &kp U                   &kp I               &kp O    &kp P          &kp MINUS
+&td_multi_mac     &kp A  &kp S  &kp D         &kp F  &kp G                   &kp H        &kp J                   &kp K               &kp L    &kp SEMICOLON  &kp GRAVE
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V  &kp B                   &kp N        &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &kp TILDE
+                                &kp LEFT_GUI  &mo 5  &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacOS";
@@ -208,10 +218,10 @@
 
         mac_code_layer {
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND      &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE   &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES  &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &sk LC(LEFT_SHIFT)
-                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE      &trans
+&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT             &kp CARET    &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&td_multi_mac     &none            &none   &none     &kp MINUS       &kp EQUAL               &kp GRAVE    &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&kp LEFT_CONTROL  &sk GLOBE        &none   &none     &kp UNDERSCORE  &kp PLUS                &kp TILDE    &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &sk LC(LEFT_SHIFT)
+                                           &trans    &trans          &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacCode";
@@ -219,10 +229,10 @@
 
         mac_number_layer {
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7    &kp NUMBER_8  &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
-&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
-&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none           &none         &none            &kp PAGE_DOWN  &sk LC(LEFT_SHIFT)
-                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &kp BACKSPACE   &trans
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6    &kp NUMBER_7            &kp NUMBER_8        &kp NUMBER_9     &kp NUMBER_0   &kp C_VOLUME_UP
+&td_multi_mac     &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp LEFT_ARROW  &kp DOWN_ARROW          &kp UP_ARROW        &kp RIGHT_ARROW  &kp PAGE_UP    &kp C_VOLUME_DOWN
+&kp LEFT_CONTROL  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &none           &none                   &none               &none            &kp PAGE_DOWN  &sk LC(LEFT_SHIFT)
+                                              &trans          &mo 5             &sm LEFT_SHIFT SPACE    &em 6 ENTER     &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacNum";
@@ -230,10 +240,10 @@
 
         mac_function_layer {
             bindings = <
-&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7         &kp F8  &kp F9  &kp F10  &none
-&td_multi_mac     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12        &none   &none   &to 8    &to WIN_DEF
-&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none          &none   &none   &none    &none
-                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &kp BACKSPACE  &trans
+&kp TAB           &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &kp F6       &kp F7                  &kp F8              &kp F9  &kp F10  &none
+&td_multi_mac     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4            &kp F11      &kp F12                 &none               &none   &to 8    &to WIN_DEF
+&kp LEFT_CONTROL  &bt BT_CLR    &none         &none         &none         &none                   &none        &none                   &none               &none   &none    &none
+                                              &trans        &trans        &sm LEFT_SHIFT SPACE    &em 6 ENTER  &bm LEFT_ALT BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
 
             label = "MacFunc";


### PR DESCRIPTION
- 設定layer標籤及層名稱
- 樣式：重構Mac功能層的綁定
- 調整function位置
- 翻譯GIT提交訊息： 維護：更新 Windows 和 macOS 的按鍵映射標籤
- 刪除mac func層切換遊戲曾按鍵
- 返回上一個能正常組建韌體的定版本
- 修改windows function
- 調整 Mac function
- 杂务：将“spotlight”标签更新为“SPOTLIGHT”
- 特性: 更新多個操作系統的快捷鍵綁定
- 工作: 為不同的作業系統和遊戲選項添加按鍵映射標籤
