### PR TITLE
性能優化：減少組合鍵綁定的超時時間

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -101,13 +101,13 @@
         combo_DEL {
             bindings = <&kp DEL>;
             key-positions = <9 10>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
         };
 
         combo_TAB {
             bindings = <&kp TAB>;
             key-positions = <1 2>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
             layers = <0 1 2 3 4 5 6 7>;
         };
 
@@ -115,26 +115,20 @@
             bindings = <&td_multi_win>;
             key-positions = <13 14>;
             layers = <0 1 2 3>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
         };
 
         combo_TD_MULTI_MAC {
             bindings = <&td_multi_mac>;
             key-positions = <13 14>;
             layers = <4 5 6 7>;
-            timeout-ms = <200>;
-        };
-
-        combo_CONTROL {
-            bindings = <&sk LEFT_CONTROL>;
-            key-positions = <25 26>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
         };
 
         combo_ALT {
             bindings = <&sk LEFT_ALT>;
             key-positions = <33 34>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
             layers = <4 5 6 7>;
         };
     };


### PR DESCRIPTION
- 將`combo_DEL`綁定的超時時間從200毫秒減少到150毫秒
- 將`combo_TAB`綁定的超時時間從200毫秒減少到150毫秒
- 將`combo_TD_MULTI_WIN`綁定的超時時間從200毫秒減少到150毫秒
- 將`combo_CONTROL`綁定的超時時間從200毫秒減少到150毫秒
- 將`combo_ALT`綁定的超時時間從200毫秒減少到150毫秒

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
