### PR TITLE
重構：調整 bspc_mod 和 left_shift_space 的按鍵綁定和輕點設定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -150,7 +150,17 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
-        bm: bspc_mod {
+        bm: bottom_row_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "BOTTOM_ROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <135>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+
+        bsm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
             bindings = <&mo>, <&kp>;
@@ -178,20 +188,20 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
-&none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                   &kp I               &kp O    &kp P          &none
+&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                   &kp K               &kp L    &kp SEMICOLON  &none
+&none  &bm LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &none
+                                  &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bsm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&none  &kp EXCLAMATION    &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp C_AL_CALENDAR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &trans             &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                  &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp EXCLAMATION    &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp C_AL_CALENDAR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &trans             &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                  &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bsm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -218,20 +228,20 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
-&none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                   &kp I               &kp O    &kp P          &none
+&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                   &kp K               &kp L    &kp SEMICOLON  &none
+&none  &bm LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &none
+                                  &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bsm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&none  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bsm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 


### PR DESCRIPTION
- 將 `bottom_row_mods` 綁定從 `bm` 修改為 `bspc_mod`
- 將 `tapping-term-ms` 值更改為 `135`
- 將 `bspc_mod` 中的 `bindings` 從 `&amp;lt;&amp;amp;mo&amp;gt;, &amp;lt;&amp;amp;kp&amp;gt;` 修改為 `&amp;lt;&amp;amp;kp&amp;gt;, &amp;lt;&amp;amp;kp&amp;gt;`
- 將 `left_shift_space` 中的 `bindings` 從 `&amp;amp;bm WIN_NUM BACKSPACE` 修改為 `&amp;amp;bsm WIN_NUM BACKSPACE`
- 將 `mac_num` 中的 `bindings` 從 `&amp;amp;bm MAC_NUM BACKSPACE` 修改為 `&amp;amp;bsm MAC_NUM BACKSPACE`

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
