### PR TITLE
release

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -101,13 +101,13 @@
         combo_DEL {
             bindings = <&kp DEL>;
             key-positions = <9 10>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
         };
 
         combo_TAB {
             bindings = <&kp TAB>;
             key-positions = <1 2>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
             layers = <0 1 2 3 4 5 6 7>;
         };
 
@@ -115,26 +115,20 @@
             bindings = <&td_multi_win>;
             key-positions = <13 14>;
             layers = <0 1 2 3>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
         };
 
         combo_TD_MULTI_MAC {
             bindings = <&td_multi_mac>;
             key-positions = <13 14>;
             layers = <4 5 6 7>;
-            timeout-ms = <200>;
-        };
-
-        combo_CONTROL {
-            bindings = <&sk LEFT_CONTROL>;
-            key-positions = <25 26>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
         };
 
         combo_ALT {
             bindings = <&sk LEFT_ALT>;
             key-positions = <33 34>;
-            timeout-ms = <200>;
+            timeout-ms = <150>;
             layers = <4 5 6 7>;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -94,8 +94,8 @@
 
         combo_ESC {
             bindings = <&kp ESC>;
-            key-positions = <3 4>;
-            timeout-ms = <200>;
+            key-positions = <1 2 3>;
+            timeout-ms = <150>;
         };
 
         combo_DEL {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -185,7 +185,7 @@
             label = "Windows";
             bindings = <
 &none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &mt LEFT_SHIFT A    &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
+&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
@@ -194,20 +194,20 @@
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&none  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &none                &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &kp C_AL_CALCULATOR  &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                    &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp EXCLAMATION    &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp C_AL_CALENDAR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &trans             &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                  &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         windows_number_layer {
             label = "WinNum";
             bindings = <
-&none  &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &none                &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none            &none
-                                          &trans          &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans           &kp LC(LEFT_SHIFT)
+&none  &kp NUMBER_1       &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &none
+&none  &kp C_AL_CALENDAR  &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &trans             &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &kp TAB          &none
+                                        &trans          &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans           &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -225,7 +225,7 @@
             label = "MacOS";
             bindings = <
 &none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &mt LEFT_SHIFT A    &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
+&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
 &none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
                                   &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
@@ -235,8 +235,8 @@
             label = "MacCode";
             bindings = <
 &none  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &none            &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &sk GLOBE        &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+&none  &kp GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
                                 &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -245,8 +245,8 @@
             label = "MacNum";
             bindings = <
 &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &none         &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &sk GLOBE     &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none            &none
+&none  &kp GLOBE     &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &trans        &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &kp TAB          &none
                                    &trans          &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans           &kp LC(LEFT_SHIFT)
             >;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -150,7 +150,17 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
-        bm: bspc_mod {
+        bm: bottom_row_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "BOTTOM_ROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <135>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+
+        bsm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
             bindings = <&mo>, <&kp>;
@@ -178,20 +188,20 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
-&none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                   &kp I               &kp O    &kp P          &none
+&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                   &kp K               &kp L    &kp SEMICOLON  &none
+&none  &bm LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &none
+                                  &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bsm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&none  &kp EXCLAMATION    &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp C_AL_CALENDAR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &trans             &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                  &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp EXCLAMATION    &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp C_AL_CALENDAR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &trans             &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                  &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bsm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -218,20 +228,20 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
-&none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
-                                  &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                   &kp I               &kp O    &kp P          &none
+&none  &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                   &kp K               &kp L    &kp SEMICOLON  &none
+&none  &bm LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &none
+                                  &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bsm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&none  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
-&none  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
+&none  &kp GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
+                                &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bsm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -106,7 +106,7 @@
 
         combo_TAB {
             bindings = <&kp TAB>;
-            key-positions = <2 3>;
+            key-positions = <3 4>;
             timeout-ms = <200>;
             layers = <0 1 2 3 4 5 6 7>;
         };
@@ -184,10 +184,10 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&none  &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
-&none  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
-                     &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
+&none  &mt LEFT_SHIFT A    &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
+&none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
+                                  &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -224,10 +224,10 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&none  &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
-&none  &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
-&none  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
-                     &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&none  &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &none
+&none  &mt LEFT_SHIFT A    &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &none
+&none  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &none
+                                  &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -205,8 +205,8 @@
             label = "WinNum";
             bindings = <
 &none  &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &none                &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none            &none
+&none  &none                &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &kp C_AL_CALCULATOR  &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none            &none
                                           &trans          &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans           &kp LC(LEFT_SHIFT)
             >;
         };
@@ -245,8 +245,8 @@
             label = "MacNum";
             bindings = <
 &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &none         &none         &kp C_NEXT      &kp C_PLAY_PAUSE  &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
-&none  &sk GLOBE     &none         &kp C_PREVIOUS  &none             &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none            &none
+&none  &none         &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &sk GLOBE     &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none            &none
                                    &trans          &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans           &kp LC(LEFT_SHIFT)
             >;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -94,7 +94,7 @@
 
         combo_ESC {
             bindings = <&kp ESC>;
-            key-positions = <1 2>;
+            key-positions = <3 4>;
             timeout-ms = <200>;
         };
 
@@ -106,7 +106,7 @@
 
         combo_TAB {
             bindings = <&kp TAB>;
-            key-positions = <3 4>;
+            key-positions = <1 2>;
             timeout-ms = <200>;
             layers = <0 1 2 3 4 5 6 7>;
         };
@@ -126,7 +126,7 @@
         };
 
         combo_CONTROL {
-            bindings = <&kp LEFT_CONTROL>;
+            bindings = <&sk LEFT_CONTROL>;
             key-positions = <25 26>;
             timeout-ms = <200>;
         };
@@ -215,7 +215,7 @@
             label = "WinFunc";
             bindings = <
 &none  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &to 8         &to 4         &none
+&none  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &to GAME_DEF  &to MAC_DEF   &none
 &none  &kp F11  &kp F12  &none   &none   &none                   &none         &none         &none               &none         &none         &none
                          &trans  &trans  &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
@@ -255,7 +255,7 @@
             label = "MacFunc";
             bindings = <
 &none  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &to 8         &to 0         &none
+&none  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &to GAME_DEF  &to WIN_DEF   &none
 &none  &kp F11  &kp F12  &none   &none   &none                   &none         &none         &none               &none         &none         &none
                          &trans  &trans  &sm LEFT_SHIFT SPACE    &trans        &trans        &kp LC(LEFT_SHIFT)
             >;
@@ -274,9 +274,9 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to 0  &none
-&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none  &none
+&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none        &none
+&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to WIN_DEF  &none
+&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
                                    &none         &trans        &trans          &none  &none  &none
             >;
         };


### PR DESCRIPTION
- 調整combo_ESC
- 性能：優化 `combo_ESC` 鍵綁定超時時間
- 性能優化：減少組合鍵綁定的超時時間
- 重構：調整 bspc_mod 和 left_shift_space 的按鍵綁定和輕點設定
