### PR TITLE
重構：更新 TAP_DANCE_MULTI_WIN 函數中 LEFT_GUI 的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -139,7 +139,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <300>;
-            bindings = <&kp LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
+            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {


### PR DESCRIPTION
- 將 `kp LEFT_GUI` 的按鍵綁定更改為 `sk LEFT_GUI` 在 `TAP_DANCE_MULTI_WIN` 函數中

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
