### PR TITLE
工作：重新安排 bsm: bspc_mod 的绑定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -139,7 +139,7 @@
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
             tapping-term-ms = <300>;
-            bindings = <&kp LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
+            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -163,12 +163,11 @@
         bsm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
-            bindings = <&mo>, <&kp>;
-
             #binding-cells = <2>;
             tapping-term-ms = <200>;
             quick-tap-ms = <125>;
             flavor = "balanced";
+            bindings = <&mo>, <&kp>;
         };
 
         sm: space_mod {


### PR DESCRIPTION
- 将 `bindings = <&amp;amp;mo>, <&amp;amp;kp>;` 行移到 `bsm: bspc_mod` 下面

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
