### PR TITLE
重構：更新`corne.keymap`文件中的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -238,7 +238,7 @@
             label = "MacCode";
             bindings = <
 &none  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &none
-&none  &kp GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
+&none  &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &none
 &none  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
                                 &trans                &trans          &sm LEFT_SHIFT SPACE    &trans     &bsm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
@@ -248,7 +248,7 @@
             label = "MacNum";
             bindings = <
 &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &none
-&none  &kp GLOBE     &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
+&none  &sk GLOBE     &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &none
 &none  &trans        &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &kp LC(Z)     &kp TAB          &none
                                    &trans          &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &trans         &trans           &kp LC(LEFT_SHIFT)
             >;


### PR DESCRIPTION
- 修改`corne.keymap`文件
- 更改`mac_code_layer`和`mac_number_layer`的綁定
- 添加`GLOBE`按鍵的綁定
- 刪除`kp EXCLAMATION`按鍵的綁定
- 更新`kp C_NEXT`按鍵的綁定
- 更新`kp MINUS`按鍵的綁定
- 更新`kp HOME`按鍵的綁定
- 更新`kp PAGE_UP`按鍵的綁定
- 更新`kp LEFT_ARROW`按鍵的綁定
- 更新`kp DOWN_ARROW`按鍵的綁定
- 更新`kp UP_ARROW`按鍵的綁定
- 更新`kp RIGHT_ARROW`按鍵的綁定
- 刪除`kp C_PREVIOUS`按鍵的綁定
- 刪除`kp C_PLAY_PAUSE`按鍵的綁定
- 刪除`kp END`按鍵的綁定
- 刪除`kp PAGE_DOWN`按鍵的

Signed-off-by: Macbook <jackie@dast.tw>
