### PR TITLE
工作: 更新corne.keymap中的點按設定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -164,7 +164,7 @@
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
             #binding-cells = <2>;
-            tapping-term-ms = <200>;
+            tapping-term-ms = <150>;
             quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&mo>, <&kp>;
@@ -174,9 +174,9 @@
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
             #binding-cells = <2>;
+            tapping-term-ms = <135>;
+            quick-tap-ms = <0>;
             flavor = "balanced";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
             bindings = <&kp>, <&kp>;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -154,8 +154,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "BOTTOM_ROW_MODS";
             #binding-cells = <2>;
-            tapping-term-ms = <135>;
-            quick-tap-ms = <0>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };
@@ -175,7 +175,7 @@
             label = "SPACE_MOD";
             #binding-cells = <2>;
             tapping-term-ms = <135>;
-            quick-tap-ms = <0>;
+            quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };


### PR DESCRIPTION
- 將`config/corne.keymap`中的`tapping-term-ms`值從135增加到200
- 將`config/corne.keymap`中的`quick-tap-ms`值從0更改為125
- 在`config/corne.keymap`中將`flavor`修改為"tap-preferred"
- 將`config/corne.keymap`中的`quick-tap-ms`值從0調整為125
- 在`config/corne.keymap`中將`flavor`更新為"balanced"

Signed-off-by: DAST-HomePC <jackie@dast.tw>
