### PR TITLE
重構：更新 bsm 和 sm 的 tapping 和 quick-tap 值

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -164,8 +164,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
             #binding-cells = <2>;
-            tapping-term-ms = <150>;
-            quick-tap-ms = <125>;
+            tapping-term-ms = <250>;
+            quick-tap-ms = <200>;
             flavor = "balanced";
             bindings = <&mo>, <&kp>;
         };
@@ -174,8 +174,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
             #binding-cells = <2>;
-            tapping-term-ms = <135>;
-            quick-tap-ms = <125>;
+            tapping-term-ms = <250>;
+            quick-tap-ms = <200>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -154,8 +154,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "BOTTOM_ROW_MODS";
             #binding-cells = <2>;
-            tapping-term-ms = <135>;
-            quick-tap-ms = <0>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };
@@ -175,7 +175,7 @@
             label = "SPACE_MOD";
             #binding-cells = <2>;
             tapping-term-ms = <135>;
-            quick-tap-ms = <0>;
+            quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };


### PR DESCRIPTION
- 將 bsm 和 sm 的 tapping-term-ms 值從150增加至250
- 將 bsm 和 sm 的 quick-tap-ms 值從125增加至200

Signed-off-by: DAST-HomePC <jackie@dast.tw>
