### PR TITLE
工作：刪除未使用的組合定義

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -92,25 +92,6 @@
     combos {
         compatible = "zmk,combos";
 
-        combo_ESC {
-            bindings = <&kp ESC>;
-            key-positions = <1 2 3>;
-            timeout-ms = <150>;
-        };
-
-        combo_DEL {
-            bindings = <&kp DEL>;
-            key-positions = <9 10>;
-            timeout-ms = <150>;
-        };
-
-        combo_TAB {
-            bindings = <&kp TAB>;
-            key-positions = <1 2>;
-            timeout-ms = <150>;
-            layers = <0 1 2 3 4 5 6 7>;
-        };
-
         combo_TD_MULTI_WIN {
             bindings = <&td_multi_win>;
             key-positions = <13 14>;


### PR DESCRIPTION
- 刪除 `combo_ESC`、`combo_DEL` 和 `combo_TAB` 組合定義

Signed-off-by: DAST-HomePC <jackie@dast.tw>
