### PR TITLE
性能優化：更新點按和快速點按的計時

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -165,8 +165,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
             #binding-cells = <2>;
-            tapping-term-ms = <250>;
-            quick-tap-ms = <200>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&mo>, <&kp>;
         };
@@ -175,8 +175,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "SPACE_MOD";
             #binding-cells = <2>;
-            tapping-term-ms = <250>;
-            quick-tap-ms = <200>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };


### PR DESCRIPTION
- 將點按時長從250修改為200
- 將快速點按時長從200修改為125

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
