### PR TITLE
特性: 重構 config/corne.keymap 中的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -188,10 +188,10 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E  &kp R         &kp T         &kp Y                   &kp U      &kp I                  &kp O               &kp P          &kp DELETE
-&td_multi_win     &kp A  &kp S  &kp D  &kp F         &kp G         &kp H                   &kp J      &kp K                  &kp L               &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C  &kp V         &kp B         &kp N                   &kp M      &kp COMMA              &kp DOT             &kp SLASH      &kp ESC
-                                       &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp DELETE
+&td_multi_win     &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &kp ESC
+                                             &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -200,7 +200,7 @@
             bindings = <
 &trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
 &trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+&trans  &sk LEFT_CONTROL     &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                      &kp LEFT_ALT          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
         };
@@ -210,7 +210,7 @@
             bindings = <
 &trans  &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &trans
 &trans  &kp C_AL_CALCULATOR  &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &trans               &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &kp LC(Z)     &kp LC(TAB)      &trans
+&trans  &sk LEFT_CONTROL     &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &kp LC(Z)     &kp LC(TAB)      &trans
                                            &kp LEFT_ALT    &mo WIN_CODE      &sm LEFT_SHIFT SPACE    &kp ENTER      &trans           &kp LC(LEFT_SHIFT)
             >;
         };
@@ -228,30 +228,30 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                   &kp I               &kp O    &kp P          &kp DELETE
-&td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                   &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &kp ESC
-                                &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE   &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q               &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                   &kp I               &kp O    &kp P          &kp DELETE
+&td_multi_mac     &kp A               &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                   &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &mt LEFT_CONTROL Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                   &kp COMMA           &kp DOT  &kp SLASH      &kp ESC
+                                             &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
         };
 
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                 &kp LEFT_GUI          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE   &kp LC(LEFT_SHIFT)
+&trans  &kp EXCLAMATION   &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND           &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE         &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE        &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &sk LEFT_CONTROL  &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES       &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                  &kp LEFT_GUI          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE   &kp LC(LEFT_SHIFT)
             >;
         };
 
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &trans
-&trans  &sk GLOBE     &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &trans        &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &kp LC(Z)     &kp LC(TAB)      &trans
-                                    &kp LEFT_GUI    &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &kp ENTER      &trans           &kp LC(LEFT_SHIFT)
+&trans  &kp NUMBER_1      &kp NUMBER_2  &kp NUMBER_3    &kp NUMBER_4      &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7     &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &sk GLOBE         &none         &kp C_NEXT      &kp MINUS         &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW   &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &sk LEFT_CONTROL  &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp END                 &kp PAGE_DOWN  &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &kp LC(Z)     &kp LC(TAB)      &trans
+                                        &kp LEFT_GUI    &mo MAC_CODE      &sm LEFT_SHIFT SPACE    &kp ENTER      &trans           &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -268,9 +268,9 @@
         game_default_layer {
             label = "Game";
             bindings = <
-&kp TAB           &none  &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
-&kp LEFT_SHIFT    &none  &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
-&kp LEFT_CONTROL  &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
+&trand  &kp TAB           &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
+&trans  &kp LEFT_SHIFT    &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
+&trans  &kp LEFT_CONTROL  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                        &sk Z         &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
             >;
         };


### PR DESCRIPTION
- 更改 `config/corne.keymap` 檔案中 `kp LEFT_CONTROL` 的綁定
- 在 `config/corne.keymap` 檔案中使用 `mt` 宏添加 `kp LEFT_CONTROL` 的新綁定
- 更改 `config/corne.keymap` 檔案中 `sk LEFT_CONTROL` 的綁定
- 更改 `config/corne.keymap` 檔案中 `kp LEFT_GUI` 的綁定
- 在 `config/corne.keymap` 檔案中使用 `mo` 宏添加 `kp LEFT_GUI` 的新綁定
- 在 `config/corne.keymap` 檔案中使用 `sm` 宏添加 `kp LEFT_GUI` 的新綁定
- 更改 `config/corne.keymap` 檔案中 `sm LEFT_SHIFT SPACE` 的綁定
- 更改 `config/corne.keymap` 檔案中 `bm WIN_NUM BACKSPACE` 的綁定
- 在 `config/corne.keymap` 檔案中添加 `kp LC(LEFT_SHIFT)` 的新綁定
- 更改 `config/corne.keymap` 檔案中

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
