### PR TITLE
特性：重構遊戲層的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -193,7 +193,7 @@
             label = "WinFunc";
             bindings = <
 &kp TAB           &kp F1   &kp F2   &kp F3        &kp F4  &kp F5                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &kp DELETE
-&td_multi_win     &kp F6   &kp F7   &kp F8        &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &to GAME_DEF  &to MAC_DEF   &kp LC(TAB)
+&td_multi_win     &kp F6   &kp F7   &kp F8        &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &none         &to GAME_DEF  &to MAC_DEF
 &kp LEFT_CONTROL  &kp F11  &kp F12  &none         &none   &none                   &none         &none         &none               &none         &none         &kp ESC
                                     &kp LEFT_ALT  &trans  &sm LEFT_SHIFT SPACE    &kp ENTER     &trans        &kp LC(LEFT_SHIFT)
             >;
@@ -233,7 +233,7 @@
             label = "MacFunc";
             bindings = <
 &kp TAB           &kp F1   &kp F2   &kp F3        &kp F4  &kp F5                  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &kp DELETE
-&td_multi_mac     &kp F6   &kp F7   &kp F8        &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &to GAME_DEF  &to WIN_DEF   &kp LEFT_ALT
+&td_multi_mac     &kp F6   &kp F7   &kp F8        &kp F9  &kp F10                 &bt BT_CLR    &none         &none               &none         &to GAME_DEF  &to WIN_DEF
 &kp LEFT_CONTROL  &kp F11  &kp F12  &none         &none   &none                   &none         &none         &none               &none         &none         &kp ESC
                                     &kp LEFT_GUI  &trans  &sm LEFT_SHIFT SPACE    &kp ENTER     &trans        &kp LC(LEFT_SHIFT)
             >;
@@ -242,9 +242,9 @@
         game_default_layer {
             label = "Game";
             bindings = <
-&trans  &kp TAB           &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
-&trans  &kp LEFT_SHIFT    &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
-&trans  &kp LEFT_CONTROL  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
+&kp TAB           &none  &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
+&kp LEFT_SHIFT    &none  &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
+&kp LEFT_CONTROL  &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
                                         &sk Z         &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
             >;
         };
@@ -252,9 +252,9 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none        &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to WIN_DEF  &none
-&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
+&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none  &none
+&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &none  &to WIN_DEF
+&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none  &none
                                    &none         &trans        &trans          &none  &none  &none
             >;
         };


### PR DESCRIPTION
- 修改 `windows_function_layer` 和 `mac_function_layer` 的綁定
- 移除 `windows_function_layer` 和 `mac_function_layer` 中 `kp LEFT_ALT` 的綁定
- 在 `mac_function_layer` 中新增 `kp LEFT_ALT` 的綁定
- 修改 `game_default_layer` 和 `game_option_layer` 的綁定
- 在 `game_default_layer` 中新增 `kp TAB` 的綁定
- 移除 `game_option_layer` 中 `kp TAB` 的綁定
- 修改 `game_option_layer` 的綁定

Signed-off-by: Macbook <jackie@dast.tw>
