### PR TITLE
ci: 更新推送觸發器和建置工作設定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - "36KEY"
       - "42KEY"
 
 jobs:


### PR DESCRIPTION
- 移除對`36KEY`分支的推送觸發器排除
- 更新`build`工作，使用`main`分支中的`build-user-config.yml`檔案

Signed-off-by: DAST-HomePC <jackie@dast.tw>
