### PR TITLE
工作：從'config/corne.keymap'中刪除'cm：code_row_mods'部分。

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -110,17 +110,6 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
-        cm: code_row_mods {
-            compatible = “zmk,behavior-hold-tap”;
-            label = “CODE_ROW_MODS”;
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
-            flavor = “tap-preferred”;
-            bindings = <&kp>, <&kp>;
-            retro-tap;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";


### PR DESCRIPTION
- 從'config/corne.keymap'中刪除'cm：code_row_mods'部分。

Signed-off-by: Macbook <jackie@dast.tw>
