### PR TITLE
42KEY

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -110,17 +110,6 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
-        cm: code_row_mods {
-            compatible = “zmk,behavior-hold-tap”;
-            label = “CODE_ROW_MODS”;
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
-            flavor = “tap-preferred”;
-            bindings = <&kp>, <&kp>;
-            retro-tap;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -110,6 +110,17 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
+        cm: code_row_mods {
+            compatible = “zmk,behavior-hold-tap”;
+            label = “CODE_ROW_MODS”;
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <0>;
+            flavor = “tap-preferred”;
+            bindings = <&kp>, <&kp>;
+            retro-tap;
+        };
+
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -110,17 +110,6 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
-        cm: code_row_mods {
-            compatible = "zmk,behavior-hold-tap";
-            label = "CODE_ROW_MODS";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
-            flavor = "tap-preferred";
-            bindings = <&kp>, <&kp>;
-            retro-tap;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -170,7 +170,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
 &td_multi_win     &kp C_AL_CALCULATOR  &none         &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
-&kp LEFT_CONTROL  &none                &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &sk LEFT_ALT  &kp LC(Z)        &kp ESC
+&kp LEFT_CONTROL  &none                &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &none         &kp LC(Z)        &kp ESC
                                                      &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
             >;
         };
@@ -190,7 +190,7 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O             &kp P          &kp DELETE
 &td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L             &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &cm LEFT_ALT DOT  &kp SLASH      &kp ESC
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &mt LEFT_ALT DOT  &kp SLASH      &kp ESC
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -210,7 +210,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
 &td_multi_mac     &sk GLOBE     &none         &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &sk LEFT_ALT  &kp LC(Z)        &kp ESC
+&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &kp LEFT_ALT  &kp LC(Z)        &kp ESC
                                               &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
             >;
         };


### PR DESCRIPTION
- 恢復正常設定
- 工作：從'config/corne.keymap'中刪除'cm：code_row_mods'部分。
