### PR TITLE
功能：重構按鍵綁定並新增Mac兼容性的新層級

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -110,17 +110,6 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
-        cm: code_row_mods {
-            compatible = “zmk,behavior-hold-tap”;
-            label = “CODE_ROW_MODS”;
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
-            flavor = “tap-preferred”;
-            bindings = <&kp>, <&kp>;
-            retro-tap;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -110,6 +110,17 @@
             bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
         };
 
+        cm: code_row_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "CODE_ROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+            retro-tap;
+        };
+
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
@@ -179,7 +190,7 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O             &kp P          &kp DELETE
 &td_multi_mac     &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L             &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &mt LEFT_ALT DOT  &kp SLASH      &kp ESC
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &cm LEFT_ALT DOT  &kp SLASH      &kp ESC
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -199,7 +210,7 @@
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
 &td_multi_mac     &sk GLOBE     &none         &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &kp LEFT_ALT  &kp LC(Z)        &kp ESC
+&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &sk LEFT_ALT  &kp LC(Z)        &kp ESC
                                               &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
             >;
         };


### PR DESCRIPTION
- 在corne.keymap文件中為code_row_mods新增一個新的行為
- 將code_row_mods行為的tapping-term-ms值更改為200
- 將retro-tap屬性添加到code_row_mods行為中
- 修改corne.keymap文件中mac_default_layer的綁定
- 將mac_default_layer中逗號鍵的綁定更改為使用cm行為而不是mt
- 在corne.keymap文件中添加一個名為mac_code_layer的新層級
- 在corne.keymap文件中添加一個名為mac_number_layer的新層級
- 修改corne.keymap文件中mac_number_layer的綁定
- 將mac_number_layer中的left_alt鍵的綁定更改為使用sk行為而不是kp

Signed-off-by: Macbook <jackie@dast.tw>
