### PR TITLE
工作: 更新`td_multi_mac`的绑定，将其从`kp LEFT_GUI`改为`kp LEFT_ALT`

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -107,7 +107,7 @@
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
             tapping-term-ms = <300>;
-            bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
+            bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
 
         cm: code_row_mods {


### PR DESCRIPTION
- 将`td_multi_mac`的绑定从`kp LEFT_GUI`更改为`kp LEFT_ALT`

Signed-off-by: Macbook <jackie@dast.tw>
