### PR TITLE
工作: 更新Windows和Mac代碼和數字層的按鍵映射綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -161,10 +161,10 @@
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none                &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                     &trans                &trans          &trans         &trans     &bm WIN_NUM BACKSPACE  &trans
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &none     &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none                &none   &none     &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                     &trans    &trans          &trans         &trans     &bm WIN_NUM BACKSPACE  &trans
             >;
         };
 
@@ -201,10 +201,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT           &kp HASH              &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &fullscreen_mac  &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none            &none            &kp PIPE              &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                          &trans                &trans          &trans         &trans     &bm MAC_NUM BACKSPACE  &trans
+&trans  &kp EXCLAMATION  &kp AT           &kp HASH  &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &fullscreen_mac  &none     &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none            &none            &none     &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                          &trans    &trans          &trans         &trans     &bm MAC_NUM BACKSPACE  &trans
             >;
         };
 


### PR DESCRIPTION
- 修改`corne.keymap`文件中`windows_code_layer`的按鍵映射綁定
- 修改`corne.keymap`文件中`windows_number_layer`的按鍵映射綁定
- 修改`corne.keymap`文件中`mac_code_layer`的按鍵映射綁定
- 修改`corne.keymap`文件中`mac_number_layer`的按鍵映射綁定

Signed-off-by: DAST-HomePC <jackie@dast.tw>
