### PR TITLE
工作：在“config/corne.keymap”中更新“td_multi_alt”的绑定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -121,7 +121,7 @@
             label = "TAP_DANCE_MULTI_ALT";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
+            bindings = <&kp LEFT_ALT>, <&kp LA(LS(EQUAL))>, <&kp LA(LS(MINUS))>;
         };
 
         td_multi_mac: tap_dance_multi_mac {


### PR DESCRIPTION
- 修改“config/corne.keymap”中“td_multi_alt”的绑定

Signed-off-by: DAST-HomePC <jackie@dast.tw>
