### PR TITLE
42KEY

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -116,6 +116,14 @@
             bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
+        td_multi_alt: tap_dance_multi_alt {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_ALT";
+            #binding-cells = <0>;
+            tapping-term-ms = <300>;
+            bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
+        };
+
         td_multi_mac: tap_dance_multi_mac {
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_MAC";
@@ -151,10 +159,10 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp DELETE
-&kp ESC           &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
-                                &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp DELETE
+&kp ESC           &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
+                                &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -87,6 +87,20 @@
                 <&macro_release>,
                 <&kp LGUI &kp LEFT_SHIFT &kp LEFT_CONTROL>;
         };
+
+        fullscreen_mac: fullscreen_mac {
+            label = "FULLSCREEN_MAC";
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp GLOBE>,
+                <&macro_wait_time 50>,
+                <&macro_tap>,
+                <&kp F>,
+                <&macro_release>,
+                <&kp GLOBE>;
+        };
     };
 
     combos {
@@ -198,20 +212,20 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DELETE
-&kp ESC           &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(TAB)
-&kp LEFT_CONTROL  &none            &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &td_multi_mac
-                                           &kp LEFT_GUI          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp EXCLAMATION  &kp AT           &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DELETE
+&kp ESC           &sk GLOBE        &fullscreen_mac  &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(TAB)
+&kp LEFT_CONTROL  &none            &none            &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &td_multi_mac
+                                                    &kp LEFT_GUI          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
-&kp ESC           &sk GLOBE     &none         &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
-&kp LEFT_CONTROL  &none         &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &sk LEFT_ALT  &kp LC(Z)        &td_multi_mac
-                                              &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
+&kp TAB           &kp NUMBER_1  &kp NUMBER_2     &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
+&kp ESC           &sk GLOBE     &fullscreen_mac  &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
+&kp LEFT_CONTROL  &none         &none            &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &sk LEFT_ALT  &kp LC(Z)        &td_multi_mac
+                                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -161,10 +161,10 @@
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none                &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                     &trans                &trans          &trans         &trans     &bm WIN_NUM BACKSPACE  &trans
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH  &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &none     &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none                &none   &none     &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                     &trans    &trans          &trans         &trans     &bm WIN_NUM BACKSPACE  &trans
             >;
         };
 
@@ -201,10 +201,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT           &kp HASH              &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &fullscreen_mac  &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none            &none            &kp PIPE              &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                          &trans                &trans          &trans         &trans     &bm MAC_NUM BACKSPACE  &trans
+&trans  &kp EXCLAMATION  &kp AT           &kp HASH  &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &fullscreen_mac  &none     &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none            &none            &none     &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                          &trans    &trans          &trans         &trans     &bm MAC_NUM BACKSPACE  &trans
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -112,7 +112,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_WIN";
             #binding-cells = <0>;
-            tapping-term-ms = <300>;
+            tapping-term-ms = <200>;
             bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
@@ -120,7 +120,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_ALT";
             #binding-cells = <0>;
-            tapping-term-ms = <300>;
+            tapping-term-ms = <200>;
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
         };
 
@@ -128,7 +128,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_MAC";
             #binding-cells = <0>;
-            tapping-term-ms = <300>;
+            tapping-term-ms = <200>;
             bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -121,7 +121,7 @@
             label = "TAP_DANCE_MULTI_ALT";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
-            bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
+            bindings = <&kp LEFT_ALT>, <&kp LA(LS(EQUAL))>, <&kp LA(LS(MINUS))>;
         };
 
         td_multi_mac: tap_dance_multi_mac {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -161,30 +161,30 @@
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&kp TAB           &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DELETE
-&kp ESC           &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(TAB)
-&kp LEFT_CONTROL  &none                &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &td_multi_win
-                                               &kp LEFT_ALT          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm WIN_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none                &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                     &trans                &trans          &trans         &trans     &bm WIN_NUM BACKSPACE  &trans
             >;
         };
 
         windows_number_layer {
             label = "WinNum";
             bindings = <
-&kp TAB           &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
-&kp ESC           &kp C_AL_CALCULATOR  &none         &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
-&kp LEFT_CONTROL  &none                &none         &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &none         &kp LC(Z)        &td_multi_win
-                                                     &kp LEFT_ALT  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
+&trans  &kp NUMBER_1         &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &kp C_AL_CALCULATOR  &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &none                &none         &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &kp LC(Z)        &trans
+                                           &trans        &mo WIN_CODE  &trans          &trans         &trans          &trans
             >;
         };
 
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&kp TAB           &kp F1   &kp F2   &kp F3          &kp F4            &kp F5                  &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &kp DELETE
-&kp ESC           &kp F6   &kp F7   &kp F8          &kp F9            &kp F10                 &bt BT_CLR    &none            &none               &none         &to GAME_DEF  &to MAC_DEF
-&kp LEFT_CONTROL  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT              &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &td_multi_win
-                                    &kp LEFT_ALT    &trans            &sm LEFT_SHIFT SPACE    &kp ENTER     &trans           &kp LC(LEFT_SHIFT)
+&trans  &kp F1   &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
+&trans  &kp F6   &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &none         &to GAME_DEF  &to MAC_DEF
+&trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
+                          &trans          &trans            &trans        &trans        &trans           &trans
             >;
         };
 
@@ -201,30 +201,30 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&kp TAB           &kp EXCLAMATION  &kp AT           &kp HASH              &kp DOLLAR      &kp PERCENT             &kp CARET  &kp AMPERSAND          &kp STAR            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DELETE
-&kp ESC           &sk GLOBE        &fullscreen_mac  &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL               &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON           &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(TAB)
-&kp LEFT_CONTROL  &none            &none            &kp PIPE              &kp UNDERSCORE  &kp PLUS                &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH           &kp LEFT_BRACE        &kp RIGHT_BRACE        &td_multi_mac
-                                                    &kp LEFT_GUI          &trans          &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
+&trans  &kp EXCLAMATION  &kp AT           &kp HASH              &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND          &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &fullscreen_mac  &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE       &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none            &none            &kp PIPE              &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES      &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                          &trans                &trans          &trans         &trans     &bm MAC_NUM BACKSPACE  &trans
             >;
         };
 
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&kp TAB           &kp NUMBER_1  &kp NUMBER_2     &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
-&kp ESC           &sk GLOBE     &fullscreen_mac  &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LG(TAB)
-&kp LEFT_CONTROL  &none         &none            &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &none         &kp LG(Z)        &td_multi_mac
-                                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
+&trans  &kp NUMBER_1  &kp NUMBER_2     &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5     &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &sk GLOBE     &fullscreen_mac  &none         &kp MINUS     &kp HOME         &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &none         &none            &none         &none         &kp END          &kp PAGE_DOWN  &none           &none           &none         &kp LG(Z)        &trans
+                                       &trans        &mo MAC_CODE  &trans           &trans         &trans          &trans
             >;
         };
 
         mac_function_layer {
             label = "MacFunc";
             bindings = <
-&kp TAB           &kp F1   &kp F2   &kp F3          &kp F4            &kp F5                  &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2        &bt BT_SEL 3  &bt BT_SEL 4  &kp DELETE
-&kp ESC           &kp F6   &kp F7   &kp F8          &kp F9            &kp F10                 &bt BT_CLR    &none            &none               &none         &to GAME_DEF  &to WIN_DEF
-&kp LEFT_CONTROL  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT              &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN   &none         &none         &td_multi_mac
-                                    &kp LEFT_GUI    &trans            &sm LEFT_SHIFT SPACE    &kp ENTER     &trans           &kp LC(LEFT_SHIFT)
+&trans  &kp F1   &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
+&trans  &kp F6   &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &none         &to GAME_DEF  &to WIN_DEF
+&trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
+                          &trans          &trans            &trans        &trans        &trans           &trans
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -124,17 +124,6 @@
             bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
 
-        cm: code_row_mods {
-            compatible = "zmk,behavior-hold-tap";
-            label = "CODE_ROW_MODS";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
-            flavor = "tap-preferred";
-            bindings = <&kp>, <&kp>;
-            retro-tap;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "BSPC_MOD";
@@ -202,9 +191,9 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O             &kp P          &kp DELETE
-&kp ESC           &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L             &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &cm LEFT_ALT DOT  &kp SLASH      &td_multi_mac
+&kp TAB           &kp Q  &kp W  &kp E         &kp R         &kp T                   &kp Y      &kp U                  &kp I               &kp O    &kp P          &kp DELETE
+&kp ESC           &kp A  &kp S  &kp D         &kp F         &kp G                   &kp H      &kp J                  &kp K               &kp L    &kp SEMICOLON  &kp LG(TAB)
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C         &kp V         &kp B                   &kp N      &kp M                  &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
                                 &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &bm MAC_NUM BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -223,8 +212,8 @@
             label = "MacNum";
             bindings = <
 &kp TAB           &kp NUMBER_1  &kp NUMBER_2     &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5            &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8        &kp NUMBER_9  &kp NUMBER_0     &kp DELETE
-&kp ESC           &sk GLOBE     &fullscreen_mac  &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(TAB)
-&kp LEFT_CONTROL  &none         &none            &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &sk LEFT_ALT  &kp LC(Z)        &td_multi_mac
+&kp ESC           &sk GLOBE     &fullscreen_mac  &none         &kp MINUS     &kp HOME                &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW      &kp UP_ARROW  &kp RIGHT_ARROW  &kp LG(TAB)
+&kp LEFT_CONTROL  &none         &none            &none         &none         &kp END                 &kp PAGE_DOWN  &none           &none               &none         &kp LG(Z)        &td_multi_mac
                                                  &kp LEFT_GUI  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER      &trans          &kp LC(LEFT_SHIFT)
             >;
         };


### PR DESCRIPTION
- 功能: 為LEFT_ALT綁定新增新的連打行為
- 重構：重新配置 `td_multi_alt` 和 `windows_code_layer` 的按鍵映射
- 性能：調整多個行為的點擊間隔
- 工作：在“config/corne.keymap”中更新“td_multi_alt”的绑定
