### PR TITLE
ci: 更新自動合併和建構工作流程

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
       - "develop"
-      - "42KEY"
+      - "build"
 
   pull_request_review:
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - "42KEY"
+      - "build"
 
 jobs:
   build:


### PR DESCRIPTION
- 從自動合併工作流程的「on」部分中刪除分支名稱「42KEY」
- 將分支名稱「build」新增至自動合併工作流程的「on」部分
- 從建構工作流程的「on」部分中刪除分支名稱「42KEY」
- 將分支名稱「build」新增至建構工作流程的「on」部分

Signed-off-by: DAST-HomePC <jackie@dast.tw>
