### PR TITLE
ci: 更新自動合併和建構工作流程

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
       - "develop"
-      - "42KEY"
+      - "build"
 
   pull_request_review:
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - "42KEY"
+      - "build"
 
 jobs:
   build:

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -209,10 +209,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT           &kp HASH  &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &fullscreen_mac  &none     &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none            &none            &none     &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                          &trans    &trans          &trans         &trans     &mo MAC_NUM        &trans
+&trans  &kp EXCLAMATION  &kp AT           &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &fullscreen_mac  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none            &none            &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                          &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
 


### PR DESCRIPTION
- 從自動合併工作流程的「on」部分中刪除分支名稱「42KEY」
- 將分支名稱「build」新增至自動合併工作流程的「on」部分
- 從建構工作流程的「on」部分中刪除分支名稱「42KEY」
- 將分支名稱「build」新增至建構工作流程的「on」部分

Signed-off-by: DAST-HomePC <jackie@dast.tw>
