### PR TITLE
功能：增加深度睡眠超時和更新板子名稱

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -11,9 +11,11 @@ CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=7
 # disables all battery level detection/reporting
 # CONFIG_ZMK_BATTERY_REPORTING=n
 
-# Set deep sleep to 30 minutes
+# Enable deep sleep support
 CONFIG_ZMK_SLEEP=y
-CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=1800000
+
+# Set deep sleep to 10 minutes
+CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=600000
 
 # Change board name
 CONFIG_ZMK_KEYBOARD_NAME="DAST Corne"


### PR DESCRIPTION
- 啟用深度睡眠支援
- 將深度睡眠超時設定為10分鐘
- 將板子名稱更改為「DAST Corne」

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
