### PR TITLE
重構: 更新 Windows 和 macOS 函數的按鍵映射配置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -261,13 +261,13 @@
         compatible = "zmk,conditional-layers";
 
         windows_function {
-            if-layers = "WIN_CODE", "WIN_NUM";
-            then-layer = "WIN_FUNC";
+            if-layers = <1 2>;
+            then-layer = <3>;
         };
 
         mac_function {
-            if-layers = "MAC_CODE", "MAC_NUM";
-            then-layer = "MAC_FUNC";
+            if-layers = <5 6>;
+            then-layer = <7>;
         };
     };
 };


### PR DESCRIPTION
- 修改 `config/corne.keymap` 中的 `windows_function` 和 `mac_function` 區塊
- 更改 `windows_function` 區塊中的 `if-layers` 和 `then-layer` 值
- 更改 `mac_function` 區塊中的 `if-layers` 和 `then-layer` 值

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
