### PR TITLE
調整部分按鍵位置

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,7 +28,7 @@ jobs:
           # 只要是 cloverdefa 帳號，都進行自動合併
           MERGE_FILTER_AUTHOR: "cloverdefa"
           # 合併後不進行自動刪除分支
-          MERGE_DELETE_BRANCH: "false"
+          # MERGE_DELETE_BRANCH: "false"
           # MERGE_DELETE_BRANCH_FILTER: "develop"
           # 合併如果發生錯誤，送出錯誤碼1
           MERGE_ERROR_FAIL: "true"

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -190,7 +190,7 @@
             label = "WinFunc";
             bindings = <
 &trans  &kp F1   &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
-&trans  &kp F6   &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &none         &to GAME_DEF  &to MAC_DEF
+&trans  &kp F6   &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to MAC_DEF      &to GAME_DEF       &none         &none         &trans
 &trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
                           &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -230,7 +230,7 @@
             label = "MacFunc";
             bindings = <
 &trans  &kp F1   &kp F2   &kp F3          &kp F4            &kp F5        &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
-&trans  &kp F6   &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &none            &none              &none         &to GAME_DEF  &to WIN_DEF
+&trans  &kp F6   &kp F7   &kp F8          &kp F9            &kp F10       &bt BT_CLR    &to WIN_DEF      &to GAME_DEF       &none         &none         &trans
 &trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_PLAY_PAUSE  &kp C_NEXT    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
                           &trans          &trans            &trans        &trans        &trans           &trans
             >;
@@ -249,10 +249,10 @@
         game_option_layer {
             label = "Option";
             bindings = <
-&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none  &none  &none  &none        &none
-&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &none  &none  &none  &to MAC_DEF  &to WIN_DEF
-&none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
-                                   &none         &trans        &trans          &none  &none  &none
+&none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &none  &none        &none        &none  &none  &none
+&none  &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none
+&none  &kp G         &none         &none         &none         &kp B           &none  &none        &none        &none  &none  &none
+                                   &none         &trans        &trans          &none  &none        &none
             >;
         };
     };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -108,20 +108,20 @@
     };
 
     behaviors {
-        td_multi_win: tap_dance_multi_win {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_WIN";
-            #binding-cells = <0>;
-            tapping-term-ms = <250>;
-            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
-        };
-
         td_multi_alt: tap_dance_multi_alt {
             compatible = "zmk,behavior-tap-dance";
             label = "TAP_DANCE_MULTI_ALT";
             #binding-cells = <0>;
             tapping-term-ms = <250>;
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
+        };
+
+        td_multi_win: tap_dance_multi_win {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_WIN";
+            #binding-cells = <0>;
+            tapping-term-ms = <250>;
+            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
         };
 
         td_multi_mac: tap_dance_multi_mac {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -116,22 +116,6 @@
             bindings = <&kp LEFT_ALT>, <&kp LA(LEFT_SHIFT)>;
         };
 
-        td_multi_win: tap_dance_multi_win {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_WIN";
-            #binding-cells = <0>;
-            tapping-term-ms = <250>;
-            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
-        };
-
-        td_multi_mac: tap_dance_multi_mac {
-            compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MULTI_MAC";
-            #binding-cells = <0>;
-            tapping-term-ms = <250>;
-            bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
-        };
-
         dm: del_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "DEL_MOD";
@@ -150,6 +134,22 @@
             quick-tap-ms = <125>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
+        };
+
+        td_multi_win: tap_dance_multi_win {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_WIN";
+            #binding-cells = <0>;
+            tapping-term-ms = <250>;
+            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
+        };
+
+        td_multi_mac: tap_dance_multi_mac {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_MAC";
+            #binding-cells = <0>;
+            tapping-term-ms = <250>;
+            bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
     };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -132,7 +132,7 @@
             bindings = <&kp LEFT_ALT>, <&spotlight>, <&screenshot_mac>;
         };
 
-        dm: delete_mod {
+        dm: del_mod {
             compatible = "zmk,behavior-hold-tap";
             label = "DEL_MOD";
             #binding-cells = <2>;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -156,6 +156,20 @@
     keymap {
         compatible = "zmk,keymap";
 
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+
+        windows_function {
+            if-layers = <1 2>;
+            then-layer = <3>;
+        };
+
+        mac_function {
+            if-layers = <5 6>;
+            then-layer = <7>;
+        };
+    };
+
         windows_default_layer {
             label = "Windows";
             bindings = <
@@ -254,20 +268,6 @@
 &none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
                                    &none         &trans        &trans          &none  &none  &none
             >;
-        };
-    };
-
-    conditional_layers {
-        compatible = "zmk,conditional-layers";
-
-        windows_function {
-            if-layers = <1 2>;
-            then-layer = <3>;
-        };
-
-        mac_function {
-            if-layers = <5 6>;
-            then-layer = <7>;
         };
     };
 };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -156,20 +156,6 @@
     keymap {
         compatible = "zmk,keymap";
 
-    conditional_layers {
-        compatible = "zmk,conditional-layers";
-
-        windows_function {
-            if-layers = <1 2>;
-            then-layer = <3>;
-        };
-
-        mac_function {
-            if-layers = <5 6>;
-            then-layer = <7>;
-        };
-    };
-
         windows_default_layer {
             label = "Windows";
             bindings = <
@@ -268,6 +254,20 @@
 &none  &kp G         &none         &none         &none         &kp B           &none  &none  &none  &none  &none        &none
                                    &none         &trans        &trans          &none  &none  &none
             >;
+        };
+    };
+
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+
+        windows_function {
+            if-layers = <1 2>;
+            then-layer = <3>;
+        };
+
+        mac_function {
+            if-layers = <5 6>;
+            then-layer = <7>;
         };
     };
 };


### PR DESCRIPTION
- 事务：调整合并分支删除配置
- 重構：重構條件層以實現跨平台相容性
- 重構：重構按鍵映射配置文件以移除條件層級
- 工作：重構按鍵映射文件以使用更清晰的命名慣例
- 工作: 重構踏步舞蹈按鍵標籤和綁定
- 事務：更新 `td_multi_win` 和 `td_multi_mac` 的按鍵映射項目
- 工作：更新功能和遊戲層的按鍵綁定
