### PR TITLE
修正：重新配置 `bspc_del` 的按鍵映射

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -146,7 +146,7 @@
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
             bindings = <&kp BACKSPACE>, <&kp DELETE>;
-            mods = <(MOD_LSFT|MOD_LGUI)>;
+            mods = <(MOD_LSFT)>;
         };
     };
 


### PR DESCRIPTION
- 修改 `config/corne.keymap` 中 `bspc_del` 的按鍵映射，只需要 `MOD_LSFT` 修飾器，不再需要 `MOD_LSFT` 和 `MOD_LGUI`。
