### PR TITLE
事務：在`config/corne.keymap`中更新`game_default_layer`的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -244,10 +244,10 @@
         game_default_layer {
             label = "Game";
             bindings = <
-&kp TAB           &none  &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
-&kp LEFT_SHIFT    &none  &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
-&kp LEFT_CONTROL  &none  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4    &none   &none   &none   &none   &none  &none
-                                       &sk Z         &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
+&kp TAB           &none         &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
+&kp LEFT_SHIFT    &none         &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
+&kp LEFT_CONTROL  &kp NUMBER_5  &kp NUMBER_4  &kp NUMBER_3  &kp NUMBER_2  &kp NUMBER_1    &none   &none   &none   &none   &none  &none
+                                              &sk Z         &mo GAME_OPT  &kp SPACE       &kp M   &none   &none
             >;
         };
 


### PR DESCRIPTION
- 修改`config/corne.keymap`中`game_default_layer`的按鍵綁定
- 在`config/corne.keymap`的`game_default_layer`中將`kp LEFT_CONTROL`與`kp NUMBER_5`的按鍵綁定交換
- 修正`config/corne.keymap`中`game_default_layer`標籤的拼字錯誤
