### PR TITLE
功能：在“windows_function_layer”中更新“BT_CLR”和“kp F6”的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -105,6 +105,14 @@
 
     combos {
         compatible = "zmk,combos";
+
+        combo_BT_CLR {
+            bindings = <&bt BT_CLR>;
+            key-positions = <18 22>;
+            timeout-ms = <20>;
+            layers = <3 7>;
+        };
+
     };
 
     behaviors {
@@ -195,7 +203,7 @@
             label = "WinFunc";
             bindings = <
 &trans  &kp F1   &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
-&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &bt BT_CLR    &to MAC_DEF      &to GAME_DEF       &none         &none         &trans
+&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &none         &to MAC_DEF      &to GAME_DEF       &none         &none         &trans
 &trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
                           &trans          &trans      &trans              &trans        &trans           &trans
             >;


### PR DESCRIPTION
- 在鍵位18和22添加新的組合綁定“BT_CLR”，超時時間為20毫秒，層級為3和7
- 刪除“windows_function_layer”中的“BT_CLR”綁定
- 更新“windows_function_layer”中的“kp F6”綁定
