### PR TITLE
翻译：

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -243,7 +243,7 @@
             label = "MacFunc";
             bindings = <
 &trans  &kp F1   &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
-&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &bt BT_CLR    &to WIN_DEF      &to GAME_DEF       &none         &none         &trans
+&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &none         &to WIN_DEF      &to GAME_DEF       &none         &none         &trans
 &trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
                           &trans          &trans      &trans              &trans        &trans           &trans
             >;


### PR DESCRIPTION
任务：重新设计`mac_function_layer`标签中的按键绑定

- 修改`mac_function_layer`标签的按键绑定
- 将`&amp;amp;bt BT_CLR`绑定更改为`&amp;amp;none`
- 移除`mac_function_layer`标签中的`&amp;amp;to GAME_DEF`绑定
