### PR TITLE
事務：更新 `LEFT_CONTROL` 和字母的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -173,8 +173,8 @@
             label = "Windows";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&kp ESC           &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
+&kp LEFT_CONTROL  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp ESC           &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
                                 &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -213,8 +213,8 @@
             label = "MacOS";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&kp ESC           &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
+&kp LEFT_CONTROL  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp ESC           &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
                                 &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };


### PR DESCRIPTION
- 修改 `corne.keymap` 檔案
- 更新 `Windows` 和 `MacOS` 的按鍵綁定
- 修改 `LEFT_CONTROL` 的按鍵綁定
- 新增 `LEFT_CONTROL` 及字母 `A`、`S`、`D`、`F`、`G`、`H`、`J`、`K`、`L`、`SEMICOLON`、`LC(TAB)`、`Z`、`X`、`C`、`V`、`B`、`N`、`M`、`COMMA`、`DOT` 和 `SLASH` 的綁定
- 對於 `Windows`，新增 `LEFT_CONTROL` 及字母 `A`、`S`、`D`、`F`、`G`、`H`、`J`、`K`、`L`、`SEMICOLON`、`LC(TAB)`、`Z`、`X`、`C`、`V`、`B`、`N`、`M`、`COMMA`、`DOT`、`SLASH`、`td_multi_alt`、`mo WIN_CODE`、

Signed-off-by: Macbook <jackie@dast.tw>
