### PR TITLE
功能：更新 MacCode 和 MacNum 標籤的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -222,20 +222,20 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT           &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &fullscreen_mac  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none            &none            &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                          &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
+&trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none            &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                        &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
 
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2     &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
-&trans  &sk GLOBE     &fullscreen_mac  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &none         &none            &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &trans
-                                       &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
+&trans  &kp NUMBER_1  &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &sk GLOBE     &kp LG(LC(F))  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &none         &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &trans
+                                     &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
             >;
         };
 


### PR DESCRIPTION
- 修改 `corne.keymap` 中的鍵綁定，為 MacCode 和 MacNum 標籤增加新功能。

Signed-off-by: Macbook <jackie@dast.tw>
