### PR TITLE
重構：更新 `WinCode` 和 `WinNum` 層的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -169,7 +169,7 @@
             label = "WinCode";
             bindings = <
 &trans  &kp EXCLAMATION  &kp AT  &kp HASH           &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LA(F4)
-&trans  &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(LA(DEL))
 &trans  &none            &none   &kp LA(LS(MINUS))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                  &trans             &trans          &trans         &trans     &mo WIN_NUM        &trans
             >;
@@ -179,7 +179,7 @@
             label = "WinNum";
             bindings = <
 &trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp LA(F4)
-&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(LA(DEL))
 &trans  &none         &none         &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &trans
                                     &trans        &mo WIN_CODE  &trans          &trans         &trans          &trans
             >;


### PR DESCRIPTION
- 修改 `corne.keymap` 檔案
- 在 `WinCode` 層中更改 `EXCLAMATION`、`AT`、`HASH`、`DOLLAR`、`PERCENT`、`CARET`、`AMPERSAND`、`STAR`、`LEFT_PARENTHESIS`、`RIGHT_PARENTHESIS` 和 `LA(F4)` 的綁定
- 在 `WinCode` 層中更改 `LS(EQUAL)`、`MINUS`、`EQUAL`、`GRAVE`、`SINGLE_QUOTE`、`NON_US_BACKSLASH`、`LEFT_BRACKET`、`RIGHT_BRACKET` 和 `LC(LA(DEL))` 的綁定
- 在 `WinCode` 層中更改 `LS(MINUS)`、`UNDERSCORE`、`PLUS`、`TILDE`、`DOUBLE_QUOTES`、`PIPE`、`LEFT_BRACE`、`RIGHT_BRACE` 和 `LA(DEL)` 的綁定
- 在 `WinNum` 層中更改 `NUMBER_1`、`NUMBER_2`、`NUMBER_3`、`NUMBER_4`、`NUMBER_5`、`NUMBER
