### PR TITLE
翻譯Git提交訊息：

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -25,14 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Automerge
-        uses: 'pascalgn/automerge-action@v0.15.6'
+        uses: 'pascalgn/automerge-action@v0.16.0'
         env:
           GITHUB_TOKEN: '${{ secrets.RELEASE_TOKEN }}'
           MERGE_LABELS: ''
           # 只要是 cloverdefa 帳號，都進行自動合併
           MERGE_FILTER_AUTHOR: "cloverdefa"
-          # 合併後不進行自動刪除分支
-          # MERGE_DELETE_BRANCH: "false"
-          # MERGE_DELETE_BRANCH_FILTER: "develop"
-          # 合併如果發生錯誤，送出錯誤碼1
-          MERGE_ERROR_FAIL: "true"


### PR DESCRIPTION
雜項：更新automerge-action並刪除註解的程式碼

- 將`automerge-action` GitHub動作的版本從`v0.15.6`更新為`v0.16.0`
- 刪除與分支刪除和錯誤處理相關的註解行
