### PR TITLE
事務：更新按鍵綁定和工作流程設定

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,15 +2,8 @@ name: Automerge
 
 on:
   pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
+    branches:
+      - "develop"
   pull_request_review:
     types:
       - submitted

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -14,8 +14,8 @@ CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=7
 # Enable deep sleep support
 CONFIG_ZMK_SLEEP=y
 
-# Set deep sleep to 20 minutes
-CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=1200000
+# Set deep sleep to 60 minutes
+CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=3600000
 
 # Change board name
 CONFIG_ZMK_KEYBOARD_NAME="DAST Corne"

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -178,8 +178,8 @@
         windows_number_layer {
             label = "WinNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp LA(F4)
-&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp LC(LA(DEL))
+&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
 &trans  &none         &none         &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &trans
                                     &trans        &mo WIN_CODE  &trans          &trans         &trans          &trans
             >;
@@ -208,9 +208,9 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &none            &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+&trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LG(LA(ESC))
+&trans  &kp LG(M)        &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
+&trans  &none            &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LG(LS(DEL))
                                         &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
@@ -218,9 +218,9 @@
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
-&trans  &sk GLOBE     &kp LG(LC(F))  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &none         &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &trans
+&trans  &kp NUMBER_1  &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp LG(LA(ESC))
+&trans  &kp LG(M)     &kp LG(LC(F))  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp LG(LC(Q))
+&trans  &none         &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &kp LG(LS(DEL))
                                      &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
             >;
         };


### PR DESCRIPTION
- 從工作流程的觸發器中刪除不必要的事件
- 將深度休眠超時更改為60分鐘
- 將面板名稱更新為「DAST Corne」
- 修改「WinNum」層的按鍵綁定
- 修改「MacCode」層的按鍵綁定
- 修改「MacNum」層的按鍵綁定
