### PR TITLE
CI：更新 automerge-action 和工作流配置

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,26 +1,29 @@
-name: Automerge
-
+name: automerge
 on:
   pull_request:
-    branches:
-      - "main"
-      - "develop"
-
-    pull_request_review:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
     types:
       - submitted
   check_suite:
     types:
       - completed
   status: {}
-
 jobs:
-  auto-merge:
+  automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: Automerge
-        uses: 'pascalgn/automerge-action@v0.15.6'
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.16.0"
         env:
-          GITHUB_TOKEN: '${{ secrets.RELEASE_TOKEN }}'
-          MERGE_LABELS: ''
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_FILTER_AUTHOR: "cloverdefa"


### PR DESCRIPTION
- 將工作流的名稱從「Automerge」更改為「automerge」
- 為拉取請求添加新的事件類型：標記、取消標記、同步、開啟、編輯、準備審查、重新開啟、解鎖
- 為拉取請求審查添加新的事件類型：提交
- 為檢查運行添加新的事件類型：完成
- 將工作的名稱從「auto-merge」更改為「automerge」
- 更新 automerge-action 的版本為 v0.16.0
- 更新環境變量中的 GITHUB_TOKEN 的值
- 刪除 MERGE_LABELS 環境變量
- 更新環境變量中的 GITHUB_TOKEN 的值
- 刪除文件末尾的換行符
