### PR TITLE
功能：重構按键绑定并更新config/corne.keymap中的元数据

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -209,8 +209,8 @@
             label = "MacCode";
             bindings = <
 &trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LG(LA(ESC))
-&trans  &kp LG(M)        &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
-&trans  &none            &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp LS(LG(DEL))
+&trans  &kp LS(LG(M))    &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
+&trans  &none            &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
                                         &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
@@ -218,10 +218,10 @@
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp LG(LA(ESC))
-&trans  &kp LG(M)     &kp LG(LC(F))  &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp LG(LC(Q))
-&trans  &none         &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &kp LG(LS(DEL))
-                                     &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
+&trans  &kp NUMBER_1   &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &kp LG(LA(ESC))
+&trans  &none          &none          &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &kp LG(LC(Q))
+&trans  &none          &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &none
+                                      &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
             >;
         };
 


### PR DESCRIPTION
- 修改config/corne.keymap中的`MacCode`和`MacNum`的按键绑定
- 修正按键绑定中的一些拼写错误
- 从按键绑定中移除不必要的代码行
- 重新排序`MacCode`和`MacNum`的按键绑定
- 更新config/corne.keymap的元数据行

Signed-off-by: Macbook <jackie@dast.tw>
