### PR TITLE
功能：更新config/corne.keymap中MacCode層的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -208,10 +208,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LG(LA(ESC))
-&trans  &kp LS(LG(M))    &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
-&trans  &none            &none          &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &none
-                                        &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
+&trans  &kp EXCLAMATION  &kp AT          &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp LS(LG(M))    &kp LG(LC(F))   &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &kp LG(LA(ESC))  kp LG(LA(ESC))  &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans              ~
+                                         &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
 


### PR DESCRIPTION
- 修改config/corne.keymap中MacCode層的按鍵綁定
- 更新特殊字符（例如EXCLAMATION，AT，HASH等）的按鍵綁定
- 在MacCode層中添加ESC按鍵綁定
- 在MacCode層中添加MAC_NUM按鍵綁定

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
