### PR TITLE
工作: 更新鍵盤映射文件的新鍵值

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -208,10 +208,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT          &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp LS(LG(M))    &kp LG(LC(F))   &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &kp LG(LA(ESC))  kp LG(LA(ESC))  &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans              ~
-                                         &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
+&trans  &kp EXCLAMATION  &kp AT           &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp LS(LG(M))    &kp LG(LC(F))    &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &kp LG(LA(ESC))  &kp LG(LA(ESC))  &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans              ~
+                                          &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };
 


### PR DESCRIPTION
- 修改 `corne.keymap` 文件
- 將 `kp LS(LG(M))` 的值改為 `&amp;kp LG(LC(F))`
- 將 `kp LG(LA(ESC))` 的值改為 `&amp;kp LG(LA(ESC))`
- 將 `kp LG(LS(D))` 的值改為 `&amp;kp LG(LS(D))`
- 將 `kp UNDERSCORE` 的值改為 `&amp;kp UNDERSCORE`
- 將 `kp PLUS` 的值改為 `&amp;kp PLUS`
- 將 `kp TILDE` 的值改為 `&amp;kp TILDE`
- 將 `kp DOUBLE_QUOTES` 的值改為 `&amp;kp DOUBLE_QUOTES`
- 將 `kp PIPE` 的值改為 `&amp;kp PIPE`
- 將 `kp LEFT_BRACE` 的值改為 `&amp;kp LEFT_BRACE`
- 將 `kp RIGHT_BRACE` 的值改為 `&amp;kp RIGHT_BRACE`

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
