### PR TITLE
工作：更新`config/corne.keymap`中的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -209,8 +209,8 @@
             label = "MacCode";
             bindings = <
 &trans  &kp EXCLAMATION  &kp AT           &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp LS(LG(M))    &kp LG(LC(F))    &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &kp LG(LA(ESC))  &kp LG(LA(ESC))  &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans              ~
+&trans  &kp LG(LS(M))    &kp LG(LC(F))    &kp LG(D)      &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &kp LG(LA(ESC))  &kp LG(LA(ESC))  &kp LG(LS(D))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                           &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };


### PR DESCRIPTION
- 修改`config/corne.keymap`中MacCode標籤的鍵綁定
- 更改`config/corne.keymap`中`LS(M)`，`LG(LS(D))`和`LG(LS(M))`的鍵綁定

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
