### PR TITLE
ci: 在GitHub工作流中實現分支過濾自動合併

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,3 +30,4 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
           MERGE_LABELS: ''
           MERGE_FILTER_AUTHOR: 'cloverdefa'
+          MERGE_DELETE_BRANCH_FILTER: 'develop'


### PR DESCRIPTION
- 添加 `MERGE_DELETE_BRANCH_FILTER` 以在GitHub工作流中過濾掉`develop`分支進行自動合併。

Signed-off-by: Macbook <jackie@dast.tw>
