### PR TITLE
風格：更新config/corne.keymap中默認圖層的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -159,8 +159,8 @@
             label = "Windows";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&kp LEFT_CONTROL  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp ESC           &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
+&kp ESC           &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
                                 &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
@@ -199,8 +199,8 @@
             label = "MacOS";
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&kp LEFT_CONTROL  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp ESC           &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
+&kp ESC           &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
                                 &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };


### PR DESCRIPTION
- 修改config/corne.keymap中`windows_default_layer`和`mac_default_layer`的綁定
- 改變兩個圖層中`&#43;kp ESC`的按鍵綁定
- 更新兩個圖層中`&#43;kp LEFT_CONTROL`的按鍵綁定
- 調整兩個圖層中`&#43;kp Z`、`&#43;kp X`、`&#43;kp C`、`&#43;kp V`、`&#43;kp B`、`&#43;kp N`、`&#43;kp M`、`&#43;kp COMMA`、`&#43;kp DOT`、`&#43;kp SLASH`的按鍵綁定
