### PR TITLE
翻譯如下：

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -152,7 +152,6 @@
             quick-tap-ms = <200>;
             flavor = "balanced";
             binding = <&kp>, <&kp>;
-            hold-trigger-key-positions = <12 24>;
         };
 
         bspc_del: backspace_delete {


### PR DESCRIPTION
差勤：刪除未使用的按鍵配置項目

- 從 `config/corne.keymap` 中刪除 `hold-trigger-key-positions` 行

Signed-off-by: Macbook <jackie@dast.tw>
