### PR TITLE
工作：優化點擊和綁定值

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -148,10 +148,10 @@
             compatible = "zmk,behavior-hold-tap";
             label = "ESC_MOD";
             #binding-cells = <2>;
-            tapping-term-ms = <100>;
-            quick-tap-ms = <200>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <125>;
             flavor = "balanced";
-            binding = <&kp>, <&kp>;
+            bindings = <&kp>, <&kp>;
         };
 
         bspc_del: backspace_delete {
@@ -171,7 +171,7 @@
 &kp TAB               &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
 &em LEFT_CONTROL ESC  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
 &em LEFT_CONTROL ESC  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
-                                &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
+                                    &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -211,7 +211,7 @@
 &kp TAB               &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
 &em LEFT_CONTROL ESC  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
 &em LEFT_CONTROL ESC  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
-                                &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
+                                    &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 


### PR DESCRIPTION
- 將“tapping-term-ms”值從100增加到200
- 將“quick-tap-ms”值從200減少到125
- 將“binding”改為“bindings”

Signed-off-by: Macbook <jackie@dast.tw>
