### PR TITLE
事務：更新休眠超時和按鍵綁定配置

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -14,8 +14,8 @@ CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=7
 # Enable deep sleep support
 CONFIG_ZMK_SLEEP=y
 
-# Set deep sleep to 60 minutes
-CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=3600000
+# Set deep sleep to 15 minutes
+CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=900000
 
 # Change board name
 CONFIG_ZMK_KEYBOARD_NAME="DAST Corne"

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -168,10 +168,10 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp TAB               &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&em LEFT_CONTROL ESC  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&em LEFT_CONTROL ESC  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
-                                    &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
+&kp TAB                       &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
+&mt LG(LCTRL) LG(LC(LA(F4)))  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&em LEFT_CONTROL ESC          &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
+                                            &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 
@@ -188,20 +188,20 @@
         windows_number_layer {
             label = "WinNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
-&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &none         &none         &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &trans
-                                    &trans        &mo WIN_CODE  &trans          &trans         &trans          &trans
+&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW     &kp DOWN_ARROW   &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &none         &none         &none         &none         &kp END         &kp PAGE_DOWN  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none         &none            &trans
+                                    &trans        &mo WIN_CODE  &trans          &trans         &trans             &trans
             >;
         };
 
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&trans  &kp F1   &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
-&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &none         &to MAC_DEF      &to GAME_DEF       &none         &none         &trans
-&trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
-                          &trans          &trans      &trans              &trans        &trans           &trans
+&trans  &kp F1   &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
+&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &none         &to MAC_DEF   &to GAME_DEF  &none         &none         &trans
+&trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &none         &none         &none         &none         &trans
+                          &trans          &trans      &trans              &trans        &trans        &trans
             >;
         };
 
@@ -228,19 +228,19 @@
         mac_number_layer {
             label = "MacNum";
             bindings = <
-&trans  &kp NUMBER_1   &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9  &kp NUMBER_0     &trans
-&trans  &none          &none          &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW  &kp DOWN_ARROW  &kp UP_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &none          &none          &none         &none         &kp END         &kp PAGE_DOWN  &none           &none           &none         &none            &none
-                                      &trans        &mo MAC_CODE  &trans          &trans         &trans          &trans
+&trans  &kp NUMBER_1   &kp NUMBER_2   &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9  &kp NUMBER_0     &trans
+&trans  &none          &none          &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW     &kp DOWN_ARROW   &kp UP_ARROW  &kp RIGHT_ARROW  &trans
+&trans  &none          &none          &none         &none         &kp END         &kp PAGE_DOWN  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &none         &none            &none
+                                      &trans        &mo MAC_CODE  &trans          &trans         &trans             &trans
             >;
         };
 
         mac_function_layer {
             label = "MacFunc";
             bindings = <
-&trans  &kp F1   &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1     &bt BT_SEL 2       &bt BT_SEL 3  &bt BT_SEL 4  &trans
-&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &none         &to WIN_DEF      &to GAME_DEF       &none         &none         &trans
-&trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &kp C_VOLUME_UP  &kp C_VOLUME_DOWN  &none         &none         &trans
+&trans  &kp F1   &kp F2   &kp F3          &kp F4      &kp F5              &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
+&trans  &kp F6   &kp F7   &kp F8          &kp F9      &kp F10             &none         &to WIN_DEF   &to GAME_DEF  &none         &none         &trans
+&trans  &kp F11  &kp F12  &kp C_PREVIOUS  &kp C_NEXT  &kp C_PLAY_PAUSE    &kp C_MUTE    &none         &none         &none         &none         &trans
                           &trans          &trans      &trans              &trans        &trans           &trans
             >;
         };


### PR DESCRIPTION
- 在 `config/corne.conf` 檔案中將休眠超時從 60 分鐘更改為 15 分鐘
- 修改 `config/corne.keymap` 檔案中的按鍵綁定，涉及 `windows_default_layer`、`windows_number_layer`、`windows_function_layer`、`mac_default_layer`、`mac_number_layer`、`mac_function_layer` 和 `game_default_layer`
