### PR TITLE
維護：重構`config/corne.keymap`中的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -144,16 +144,6 @@
             bindings = <&kp>, <&kp>;
         };
 
-        em: esc_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "ESC_MOD";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <125>;
-            flavor = "balanced";
-            bindings = <&kp>, <&kp>;
-        };
-
         bspc_del: backspace_delete {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
@@ -168,20 +158,20 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp TAB                   &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&mt LG(LCTRL) LG(LC(F4))  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&em LEFT_CONTROL ESC      &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
-                                        &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
+&kp TAB            &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
+&mt LG(LCTRL) ESC  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL   &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_win
+                                 &td_multi_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&trans  &kp EXCLAMATION  &kp AT  &kp HASH           &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LA(F4)
-&trans  &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(LA(DEL))
-&trans  &none            &none   &kp LA(LS(MINUS))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                 &trans             &trans          &trans         &trans     &mo WIN_NUM        &trans
+&trans          &kp EXCLAMATION  &kp AT  &kp HASH           &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LA(F4)
+&kp LG(LC(F4))  &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp EQUAL      &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(LA(DEL))
+&trans          &none            &none   &kp LA(LS(MINUS))  &kp UNDERSCORE  &kp PLUS       &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                         &trans             &trans          &trans         &trans     &mo WIN_NUM        &trans
             >;
         };
 
@@ -208,10 +198,10 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&kp TAB               &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&em LEFT_CONTROL ESC  &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&em LEFT_CONTROL ESC  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
-                                    &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
+&kp TAB           &kp Q  &kp W  &kp E          &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
+&kp ESC           &kp A  &kp S  &kp D          &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C          &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_multi_mac
+                                &td_multi_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
             >;
         };
 


### PR DESCRIPTION
- 移除`config/corne.keymap`中的`em: esc_mod`區塊
- 修改`config/corne.keymap`中的`windows_default_layer`綁定
- 修改`config/corne.keymap`中的`windows_code_layer`綁定
- 修改`config/corne.keymap`中的`mac_default_layer`綁定
- 修改`config/corne.keymap`中的`mac_code_layer`綁定
