### PR TITLE
事務：更新不同按鍵的鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -158,10 +158,10 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp TAB            &kp Q  &kp W  &kp E    &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
-&mt LG(LCTRL) ESC  &kp A  &kp S  &kp D    &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL   &kp Z  &kp X  &kp C    &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_win
-                                 &td_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &kp LC(LEFT_SHIFT)
+&kp TAB            &kp Q  &kp W  &kp E    &kp R         &kp T                   &kp Y      &kp U        &kp I      &kp O    &kp P          &bspc_del
+&mt LG(LCTRL) ESC  &kp A  &kp S  &kp D    &kp F         &kp G                   &kp H      &kp J        &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL   &kp Z  &kp X  &kp C    &kp V         &kp B                   &kp N      &kp M        &kp COMMA  &kp DOT  &kp SLASH      &kp LC(LEFT_SHIFT)
+                                 &td_alt  &mo WIN_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo WIN_NUM  &td_win
             >;
         };
 
@@ -200,8 +200,8 @@
             bindings = <
 &kp TAB           &kp Q  &kp W  &kp E    &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
 &kp ESC           &kp A  &kp S  &kp D    &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z  &kp X  &kp C    &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &td_mac
-                                &td_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &kp LC(LEFT_SHIFT)
+&kp LEFT_CONTROL  &kp Z  &kp X  &kp C    &kp V         &kp B                   &kp N      &kp M        &kp COMMA           &kp DOT  &kp SLASH      &kp LC(LEFT_SHIFT)
+                                &td_cmd  &mo MAC_CODE  &sm LEFT_SHIFT SPACE    &kp ENTER  &mo MAC_NUM  &td_mac
             >;
         };
 


### PR DESCRIPTION
- 修改 `左控制`、`Z`、`X`、`C`、`V`、`B`、`N`、`M`、`逗號`、`句號`、`斜線` 和 `左 Shift` (`LC`) 按鍵的鍵綁定
- 在第 160 和第 200 行更改 `TAB` 鍵的 `bindings` 值
- 更新第 160 和第 200 行的 `R` 鍵 `bindings` 值
- 在第 160 行將 `ESCAPE` 鍵綁定替換為 `ESC` 鍵綁定
- 在第 160 和第 200 行添加 `sm 左 Shift 空格` 的鍵綁定
- 修改 `ALT`、`WIN_CODE`、`WIN_NUM`、`MAC_CODE`、`MAC_NUM` 和 `CMD` 按鍵的 `&amp;td` 值
- 在第 160 行刪除 `TD_ALT` 按鍵綁定
- 在第 160

Signed-off-by: Macbook <jackie@dast.tw>
