### PR TITLE
重構：更新操作系統和遊戲層的顯示名稱

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -156,7 +156,7 @@
         compatible = "zmk,keymap";
 
         windows_default_layer {
-            label = "Windows";
+            display-name = "Windows";
             bindings = <
 &kp TAB               &kp Q  &kp W  &kp E    &kp R         &kp T                   &kp Y      &kp U        &kp I      &kp O    &kp P          &bspc_del
 &mt LEFT_CONTROL ESC  &kp A  &kp S  &kp D    &kp F         &kp G                   &kp H      &kp J        &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
@@ -166,7 +166,7 @@
         };
 
         windows_code_layer {
-            label = "WinCode";
+            display-name = "WinCode";
             bindings = <
 &trans          &kp EXCLAMATION  &kp AT  &kp HASH           &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LA(F4)
 &kp LG(LCTRL)   &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp PLUS       &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(LA(DEL))
@@ -176,7 +176,7 @@
         };
 
         windows_number_layer {
-            label = "WinNum";
+            display-name = "WinNum";
             bindings = <
 &trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9    &kp NUMBER_0     &trans
 &trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW     &kp DOWN_ARROW   &kp UP_ARROW    &kp RIGHT_ARROW  &trans
@@ -186,7 +186,7 @@
         };
 
         windows_function_layer {
-            label = "WinFunc";
+            display-name = "WinFunc";
             bindings = <
 &trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
 &trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10    &none         &to MAC_DEF   &to GAME_DEF  &none         &none         &trans
@@ -196,7 +196,7 @@
         };
 
         mac_default_layer {
-            label = "MacOS";
+            display-name = "MacOS";
             bindings = <
 &kp TAB               &kp Q  &kp W  &kp E    &kp R         &kp T                   &kp Y      &kp U        &kp I               &kp O    &kp P          &bspc_del
 &mt LEFT_CONTROL ESC  &kp A  &kp S  &kp D    &kp F         &kp G                   &kp H      &kp J        &kp K               &kp L    &kp SEMICOLON  &kp LC(TAB)
@@ -206,7 +206,7 @@
         };
 
         mac_code_layer {
-            label = "MacCode";
+            display-name = "MacCode";
             bindings = <
 &trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
 &trans  &kp LG(LS(M))    &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp PLUS       &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
@@ -216,7 +216,7 @@
         };
 
         mac_number_layer {
-            label = "MacNum";
+            display-name = "MacNum";
             bindings = <
 &trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9    &kp NUMBER_0     &trans
 &trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW     &kp DOWN_ARROW   &kp UP_ARROW    &kp RIGHT_ARROW  &trans
@@ -226,7 +226,7 @@
         };
 
         mac_function_layer {
-            label = "MacFunc";
+            display-name = "MacFunc";
             bindings = <
 &trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
 &trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10    &none         &to WIN_DEF   &to GAME_DEF  &none         &none         &trans
@@ -236,7 +236,7 @@
         };
 
         game_default_layer {
-            label = "Game";
+            display-name = "Game";
             bindings = <
 &kp TAB           &none         &kp Q         &kp W         &kp E         &kp R           &kp F1  &kp F2  &kp F3  &kp F4  &none  &none
 &kp LEFT_SHIFT    &none         &kp A         &kp S         &kp D         &none           &none   &none   &none   &none   &none  &none
@@ -246,7 +246,7 @@
         };
 
         game_option_layer {
-            label = "Option";
+            display-name = "Option";
             bindings = <
 &kp NUMBER_6  &kp NUMBER_5  &kp NUMBER_4  &kp NUMBER_3  &kp NUMBER_2  &kp NUMBER_1    &none  &none        &none        &none  &none  &none
 &kp ESCAPE    &none         &kp NUMBER_0  &kp NUMBER_9  &kp NUMBER_8  &kp NUMBER_7    &none  &to WIN_DEF  &to MAC_DEF  &none  &none  &none


### PR DESCRIPTION
- 在 `windows_default_layer`、`windows_code_layer`、`windows_number_layer`、`windows_function_layer`、`mac_default_layer`、`mac_code_layer`、`mac_number_layer`、`mac_function_layer`、`game_default_layer` 和 `game_option_layer` 中將 `label` 欄位更改為 `display-name`
- 在 `windows_default_layer` 中添加 `display-name = &#34;Windows&#34;`
- 在 `windows_code_layer` 中添加 `display-name = &#34;WinCode&#34;`
- 在 `windows_number_layer` 中添加 `display-name = &#34;WinNum&#34;`
- 在 `windows_function_layer` 中添加 `display-name = &#34;WinFunc&#34;`
- 在 `mac_default_layer` 中添加 `display-name = &#34;MacOS&#34;`
- 在 `mac_code_layer` 中添加 `display-name = &#34;MacCode&#34;`
- 在 `mac_number_layer` 中添加 `display-name = &#34;MacNum&#34;`
- 在 `mac_function_layer`

Signed-off-by: Macbook <jackie@dast.tw>
