### PR TITLE
工作：更新 WinCode 層的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -169,7 +169,7 @@
             display-name = "WinCode";
             bindings = <
 &trans          &kp EXCLAMATION  &kp AT  &kp HASH           &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LA(F4)
-&kp LG(LCTRL)   &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp PLUS       &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(LA(DEL))
+&trans          &none            &none   &kp LA(LS(EQUAL))  &kp MINUS       &kp PLUS       &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LC(LA(DEL))
 &kp LG(LC(F4))  &none            &none   &kp LA(LS(MINUS))  &kp UNDERSCORE  &kp EQUAL      &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                          &trans             &trans          &trans         &trans     &mo WIN_NUM        &trans
             >;


### PR DESCRIPTION
- 修改 `corne.keymap` 中 `WinCode` 層的按鍵綁定
- 將 `EXCLAMATION` 的按鍵綁定改為 `kp EXCLAMATION`
- 將 `AT` 的按鍵綁定改為 `kp AT`
- 將 `HASH` 的按鍵綁定改為 `kp HASH`
- 將 `DOLLAR` 的按鍵綁定改為 `kp DOLLAR`
- 將 `PERCENT` 的按鍵綁定改為 `kp PERCENT`
- 將 `CARET` 的按鍵綁定改為 `kp CARET`
- 將 `AMPERSAND` 的按鍵綁定改為 `kp AMPERSAND`
- 將 `STAR` 的按鍵綁定改為 `kp STAR`
- 將 `LEFT_PARENTHESIS` 的按鍵綁定改為 `kp LEFT_PARENTHESIS`
- 將 `RIGHT_PARENTHESIS` 的按鍵綁定改為
