### PR TITLE
develop

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -220,7 +220,7 @@
             bindings = <
 &trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6    &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9     &kp NUMBER_0   &trans
 &trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp LEFT_ARROW  &kp DOWN_ARROW     &kp UP_ARROW     &kp RIGHT_ARROW  &kp PAGE_UP    &trans
-&trans  &none         &none         &none         &none         &kp END         &kp C_NEXT      &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp C_PREVIOUS   &kp PAGE_DOWN  &none
+&trans  &none         &none         &none         &none         &kp END         &kp C_NEXT      &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp C_PREVIOUS   &kp PAGE_DOWN  &trans
                                     &trans        &mo MAC_CODE  &trans          &trans          &trans             &trans
             >;
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -218,10 +218,10 @@
         mac_number_layer {
             display-name = "MacNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9    &kp NUMBER_0     &trans
-&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW     &kp DOWN_ARROW   &kp UP_ARROW    &kp RIGHT_ARROW  &trans
-&trans  &none         &none         &none         &none         &kp END         &kp PAGE_DOWN  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp C_PREVIOUS  &kp C_NEXT       &none
-                                    &trans        &mo MAC_CODE  &trans          &trans         &trans             &trans
+&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6    &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9     &kp NUMBER_0   &trans
+&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp LEFT_ARROW  &kp DOWN_ARROW     &kp UP_ARROW     &kp RIGHT_ARROW  &kp PAGE_UP    &trans
+&trans  &none         &none         &none         &none         &kp END         &kp C_NEXT      &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp C_PREVIOUS   &kp PAGE_DOWN  &none
+                                    &trans        &mo MAC_CODE  &trans          &trans          &trans             &trans
             >;
         };
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -178,10 +178,10 @@
         windows_number_layer {
             display-name = "WinNum";
             bindings = <
-&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6   &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9    &kp NUMBER_0     &trans
-&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp PAGE_UP    &kp LEFT_ARROW     &kp DOWN_ARROW   &kp UP_ARROW    &kp RIGHT_ARROW  &trans
-&trans  &none         &none         &none         &none         &kp END         &kp PAGE_DOWN  &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp C_PREVIOUS  &kp C_NEXT       &trans
-                                    &trans        &mo WIN_CODE  &trans          &trans         &trans             &trans
+&trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5    &kp NUMBER_6    &kp NUMBER_7       &kp NUMBER_8     &kp NUMBER_9     &kp NUMBER_0   &trans
+&trans  &none         &none         &none         &kp MINUS     &kp HOME        &kp LEFT_ARROW  &kp DOWN_ARROW     &kp UP_ARROW     &kp RIGHT_ARROW  &kp PAGE_UP    &trans
+&trans  &none         &none         &none         &none         &kp END         &kp C_NEXT      &kp C_VOLUME_DOWN  &kp C_VOLUME_UP  &kp C_PREVIOUS   &kp PAGE_DOWN  &trans
+                                    &trans        &mo WIN_CODE  &trans          &trans          &trans             &trans
             >;
         };
 


### PR DESCRIPTION
- 重構：更新Windows數字層的按鍵映射配置
- 重構：重構配置文件中 MacNum 層的按鍵綁定
- 工作：在`config/corne.keymap`中更新`mac_number_layer`的绑定
