### PR TITLE
重構：更新Combo_WIN_NEWDESKTOP綁定中的鍵位

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -101,7 +101,7 @@
 
         Combo_WIN_NEWDESKTOP {
             bindings = <&kp LG(LC(D))>;
-            key-positions = <12 13>;
+            key-positions = <24 25>;
             timeout-ms = <20>;
             layers = <0>;
         };


### PR DESCRIPTION
- 將Combo_WIN_NEWDESKTOP綁定中的`key-positions`從`&lt;12 13&gt;`修改為`&lt;24 25&gt;`
- `config/corne.keymap`文件中沒有進行其他更改
