### PR TITLE
工作：更新 MacCode 的按键映射绑定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -216,8 +216,8 @@
             display-name = "MacCode";
             bindings = <
 &trans  &kp EXCLAMATION  &kp AT         &kp HASH       &kp DOLLAR      &kp PERCENT    &kp CARET  &kp AMPERSAND      &kp STAR              &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LG(LA(ESC))
-&trans  &kp LG(LS(M))    &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp PLUS       &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
-&trans  &trans           &kp LG(GRAVE)  &kp LG(LS(D))  &kp UNDERSCORE  &kp EQUAL      &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+&trans  &none            &kp LG(LC(F))  &kp LG(D)      &kp MINUS       &kp PLUS       &kp GRAVE  &kp SINGLE_QUOTE   &kp NON_US_BACKSLASH  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp LG(LC(Q))
+&trans  &none            &kp LG(LS(M))  &kp LG(LS(D))  &kp UNDERSCORE  &kp EQUAL      &kp TILDE  &kp DOUBLE_QUOTES  &kp PIPE              &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                         &trans         &trans          &trans         &trans     &mo MAC_NUM        &trans
             >;
         };


### PR DESCRIPTION
- 修改 `corne.keymap` 文件
- 更新 `MacCode` 的绑定
- 移除 `&amp;amp;kp LG(GRAVE)`
- 添加 `&amp;amp;none` 绑定给 `&amp;amp;kp LG(LS(M))`
- 添加 `&amp;amp;none` 绑定给 `&amp;amp;kp LG(LS(D))`
