### PR TITLE
develop

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -105,12 +105,6 @@
             timeout-ms = <20>;
             layers = <0>;
         };
-
-        combo_MAC_TERMINALWINDOW
-            binding = <&kp LG(LEFT_ALT)>;
-            key-positions = <24 25>;
-            timeout-ms = <20>;
-            layers = <4>;
     };
 
     behaviors {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -101,7 +101,7 @@
 
         combo_WIN_NEWDESKTOP {
             bindings = <&kp LG(LC(D))>;
-            key-positions = <36 37>;
+            key-positions = <24 25>;
             timeout-ms = <20>;
             layers = <0>;
         };


### PR DESCRIPTION
- 工作: 刪除對「combo_MAC_TERMINALWINDOW」的綁定
- 重構：更新 combo_WIN_NEWDESKTOP 的按鍵位置
