### PR TITLE
重構：從corne.keymap文件中刪除冗餘代碼

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -58,7 +58,7 @@
                 <&kp UP_ARROW>,
                 <&macro_release>,
                 <&kp LGUI>;
-        }
+        };
 
         screenshot_win: screenshot_win {
             label = "SCREENSHOT_WIN";


### PR DESCRIPTION
- 從`corne.keymap`文件中刪除冗餘代碼。

Signed-off-by: DAST-HomePC <jackie@dast.tw>
